### PR TITLE
rename docker container

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,7 +100,7 @@ jobs:
           docker-compose -f docker/docker-compose-postgres.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
-          docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+          docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
       - name: test
         run: sbt ++${{ matrix.SCALA_VERSION }} test
@@ -139,7 +139,7 @@ jobs:
           docker-compose -f docker/docker-compose-postgres.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
-          docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+          docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
       - name: test
         run: sbt ++3.3 core/test

--- a/.github/workflows/nightly-tests-pekko1.1.yml
+++ b/.github/workflows/nightly-tests-pekko1.1.yml
@@ -98,7 +98,7 @@ jobs:
           docker-compose -f docker/docker-compose-postgres.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
-          docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+          docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
       - name: test
         run: sbt -Dpekko.build.pekko.version=main ++${{ matrix.SCALA_VERSION }} test
@@ -137,7 +137,7 @@ jobs:
           docker-compose -f docker/docker-compose-postgres.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
-          docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+          docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
       - name: test
         run: sbt -Dpekko.build.pekko.version=main ++3.3 core/test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,13 @@ docker-compose -f docker/docker-compose-postgres.yml up
 ```
 
 ```
-docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 ```
 
 ## Some useful debug queries for Postgres
 
 ```
-docker exec -it docker_postgres-db_1 psql -U postgres
+docker exec -it docker-postgres-db-1 psql -U postgres
 ```
 
 ```

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,7 +1,7 @@
-version: '2.2'
 services:
   postgres-db:
     image: postgres:latest
+    container_name: docker-postgres-db-1
     ports:
       - 5432:5432
     environment:

--- a/docker/docker-compose-yugabyte.yml
+++ b/docker/docker-compose-yugabyte.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 # Local Yugabyte database, see https://docs.yugabyte.com/latest/deploy/docker/docker-compose/
 
 volumes:

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -68,7 +68,7 @@ The ddl script can be run in Docker with:
 
 Postgres:
 : ```
-docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
+docker exec -i docker-postgres-db-1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 ```
 
 Yugabyte:


### PR DESCRIPTION
* when testing locally on a Macbook, my up to date version of Docker seems to dislike `_` in container names
* container is created but with `_` replaced by `-`
* this causes other commands to fail
* the version setting in the docker-compose yml files is now also obsolete - leads to warnings