### PR TITLE
add back snapshot resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ import sbt.Keys.parallelExecution
 sourceDistName := "apache-pekko-persistence-r2dbc"
 sourceDistIncubating := false
 
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 GlobalScope / parallelExecution := false


### PR DESCRIPTION
change in #162 broke some builds - eg https://github.com/apache/pekko-persistence-r2dbc/actions/runs/11528749928

The issue is similar to https://github.com/apache/pekko-connectors/pull/877

I will try to to the bottom of why using addPekkoModuleDependency is causing build issues for this module but my 1st priority is to get the CI builds working again.