### PR TITLE
Add ConnectionFactoryOptionsCustomizer

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -170,11 +170,11 @@ pekko.persistence.r2dbc {
     # A fast query for Postgres is "SELECT 1"
     validation-query = ""
 
-    # FQCN of an OptionsCustomizer. If non-empty, it must be the fully qualified class
-    # name of a class implementing the trait ConnectionFactoryProvider.OptionsCustomizer.
+    # FQCN of a ConnectionFactoryOptionsCustomizer. If non-empty, it must be the fully
+    # qualified class name of a class implementing the trait ConnectionFactoryOptionsCustomizer.
     # The class must have a constructor with a single parameter of type ActorSystem[_].
     # If this setting is empty, the default no-op customizer will be used.
-    options-customizer = ""
+    connection-factory-options-customizer = ""
   }
 
   # If database timestamp is guaranteed to not move backwards for two subsequent

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -169,6 +169,12 @@ pekko.persistence.r2dbc {
     # Enabling this has some performance overhead.
     # A fast query for Postgres is "SELECT 1"
     validation-query = ""
+
+    # FQCN of an OptionsCustomizer. If non-empty, it must be the fully qualified class
+    # name of a class implementing the trait ConnectionFactoryProvider.OptionsCustomizer.
+    # The class must have a constructor with a single parameter of type ActorSystem[_].
+    # If this setting is empty, the default no-op customizer will be used.
+    options-customizer = ""
   }
 
   # If database timestamp is guaranteed to not move backwards for two subsequent

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -89,7 +89,8 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
         system.dynamicAccess.createInstanceFor[ConnectionFactoryOptionsCustomizer](fqcn, args) match {
           case Success(customizer) => customizer
           case Failure(cause) =>
-            throw new RuntimeException("Failed to create ConnectionFactoryOptionsCustomizer", cause)
+            throw new IllegalArgumentException(s"Failed to create ConnectionFactoryOptionsCustomizer for class $fqcn",
+              cause)
         }
     }
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -46,11 +46,12 @@ object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] 
   def get(system: ActorSystem[_]): ConnectionFactoryProvider = apply(system)
 
   trait ConnectionFactoryOptionsCustomizer {
-    def apply(options: ConnectionFactoryOptions, config: Config): ConnectionFactoryOptions
+    def apply(builder: ConnectionFactoryOptions.Builder, config: Config): ConnectionFactoryOptions.Builder
   }
 
   private object NoopCustomizer extends ConnectionFactoryOptionsCustomizer {
-    override def apply(options: ConnectionFactoryOptions, config: Config): ConnectionFactoryOptions = options
+    override def apply(builder: ConnectionFactoryOptions.Builder, config: Config): ConnectionFactoryOptions.Builder =
+      builder
   }
 }
 
@@ -131,7 +132,7 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
         builder.option(PostgresqlConnectionFactoryProvider.SSL_ROOT_CERT, settings.sslRootCert)
     }
 
-    ConnectionFactories.get(customizer(builder.build(), config))
+    ConnectionFactories.get(customizer(builder, config).build())
   }
 
   private def createConnectionPoolFactory(settings: ConnectionFactorySettings,

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.util._
+import scala.util.Failure
+import scala.util.Success
 
 import com.typesafe.config.Config
 import org.apache.pekko

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -18,8 +18,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{ Failure, Success }
 
 import com.typesafe.config.Config
 import org.apache.pekko

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -44,7 +44,25 @@ object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] 
   // Java API
   def get(system: ActorSystem[_]): ConnectionFactoryProvider = apply(system)
 
+  /**
+   * Enables customization of [[ConnectionFactoryOptions]] right before the connection factory is created.
+   * This is particularly useful for setting options that support dynamically computed values rather than
+   * just plain constants. Classes implementing this trait must have a constructor with a single parameter
+   * of type [[ActorSystem]].
+   *
+   * @since 1.1.0
+   */
   trait ConnectionFactoryOptionsCustomizer {
+
+    /**
+     * Customizes the [[ConnectionFactoryOptions.Builder]] instance based on the provided configuration.
+     *
+     * @param builder the options builder that has been pre-configured by the connection factory provider
+     * @param config  the connection factory configuration
+     * @return        the modified options builder with the applied customizations
+     *
+     * @since 1.1.0
+     */
     def apply(builder: ConnectionFactoryOptions.Builder, config: Config): ConnectionFactoryOptions.Builder
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -143,6 +143,6 @@ final class ConnectionFactorySettings(config: Config) {
 
   val statementCacheSize: Int = config.getInt("statement-cache-size")
 
-  val optionsCustomizer: Option[String] =
-    Option(config.getString("options-customizer")).filter(_.trim.nonEmpty)
+  val connectionFactoryOptionsCustomizer: Option[String] =
+    Option(config.getString("connection-factory-options-customizer")).filter(_.trim.nonEmpty)
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -142,4 +142,7 @@ final class ConnectionFactorySettings(config: Config) {
   val validationQuery: String = config.getString("validation-query")
 
   val statementCacheSize: Int = config.getInt("statement-cache-size")
+
+  val optionsCustomizer: Option[String] =
+    Option(config.getString("options-customizer")).filter(_.trim.nonEmpty)
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.persistence.r2dbc

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -26,6 +26,7 @@ import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.eventstream.EventStream
 import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.CustomizerCalled
 import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.config
+import org.apache.pekko.persistence.r2dbc.ConnectionFactoryProvider.ConnectionFactoryOptionsCustomizer
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class ConnectionFactoryOptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWordSpecLike {
@@ -43,10 +44,10 @@ class ConnectionFactoryOptionsCustomizerSpec extends ScalaTestWithActorTestKit(c
 object ConnectionFactoryOptionsCustomizerSpec {
   object CustomizerCalled
 
-  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryProvider.ConnectionFactoryOptionsCustomizer {
-    override def apply(options: ConnectionFactoryOptions, config: Config): ConnectionFactoryOptions = {
+  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryOptionsCustomizer {
+    override def apply(builder: ConnectionFactoryOptions.Builder, config: Config): ConnectionFactoryOptions.Builder = {
       system.eventStream.tell(EventStream.Publish(CustomizerCalled))
-      options
+      builder
     }
   }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -14,12 +14,12 @@ import io.r2dbc.spi.ConnectionFactoryOptions
 import org.apache.pekko.actor.testkit.typed.scaladsl._
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.eventstream.EventStream
-import org.apache.pekko.persistence.r2dbc.OptionsCustomizerSpec._
+import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec._
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class OptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWordSpecLike {
+class ConnectionFactoryOptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWordSpecLike {
   "ConnectionFactoryProvider" should {
-    "instantiate and apply a custom OptionsCustomizer when options-customizer settings is set" in {
+    "instantiate and apply a custom ConnectionFactoryOptionsCustomizer when connection-factory-options-customizer settings is set" in {
       val probe = TestProbe[CustomizerCalled.type]()
       system.eventStream.tell(EventStream.Subscribe(probe.ref))
 
@@ -29,10 +29,10 @@ class OptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWo
   }
 }
 
-object OptionsCustomizerSpec {
+object ConnectionFactoryOptionsCustomizerSpec {
   object CustomizerCalled
 
-  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryProvider.OptionsCustomizer {
+  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryProvider.ConnectionFactoryOptionsCustomizer {
     override def apply(options: ConnectionFactoryOptions, config: Config): ConnectionFactoryOptions = {
       system.eventStream.tell(EventStream.Publish(CustomizerCalled))
       options
@@ -41,7 +41,7 @@ object OptionsCustomizerSpec {
 
   val config: Config = ConfigFactory.parseString("""
     pekko.persistence.r2dbc.connection-factory {
-      options-customizer = "org.apache.pekko.persistence.r2dbc.OptionsCustomizerSpec$Customizer"
+      connection-factory-options-customizer = "org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec$Customizer"
     }
     """).withFallback(TestConfig.config)
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -17,15 +17,12 @@
 
 package org.apache.pekko.persistence.r2dbc
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 import io.r2dbc.spi.ConnectionFactoryOptions
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import org.apache.pekko.actor.testkit.typed.scaladsl.TestProbe
+import org.apache.pekko.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.eventstream.EventStream
-import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.CustomizerCalled
-import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.config
+import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.{ config, CustomizerCalled }
 import org.apache.pekko.persistence.r2dbc.ConnectionFactoryProvider.ConnectionFactoryOptionsCustomizer
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -17,12 +17,15 @@
 
 package org.apache.pekko.persistence.r2dbc
 
-import com.typesafe.config._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import io.r2dbc.spi.ConnectionFactoryOptions
-import org.apache.pekko.actor.testkit.typed.scaladsl._
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko.actor.testkit.typed.scaladsl.TestProbe
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.eventstream.EventStream
-import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec._
+import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.CustomizerCalled
+import org.apache.pekko.persistence.r2dbc.ConnectionFactoryOptionsCustomizerSpec.config
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class ConnectionFactoryOptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWordSpecLike {

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/OptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/OptionsCustomizerSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.persistence.r2dbc
+
+import com.typesafe.config._
+import io.r2dbc.spi.ConnectionFactoryOptions
+import org.apache.pekko.actor.testkit.typed.scaladsl._
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.eventstream.EventStream
+import org.apache.pekko.persistence.r2dbc.OptionsCustomizerSpec._
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class OptionsCustomizerSpec extends ScalaTestWithActorTestKit(config) with AnyWordSpecLike {
+  "ConnectionFactoryProvider" should {
+    "instantiate and apply a custom OptionsCustomizer when options-customizer settings is set" in {
+      val probe = TestProbe[CustomizerCalled.type]()
+      system.eventStream.tell(EventStream.Subscribe(probe.ref))
+
+      ConnectionFactoryProvider(system).connectionFactoryFor("pekko.persistence.r2dbc.connection-factory")
+      probe.expectMessage(CustomizerCalled)
+    }
+  }
+}
+
+object OptionsCustomizerSpec {
+  object CustomizerCalled
+
+  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryProvider.OptionsCustomizer {
+    override def apply(options: ConnectionFactoryOptions, config: Config): ConnectionFactoryOptions = {
+      system.eventStream.tell(EventStream.Publish(CustomizerCalled))
+      options
+    }
+  }
+
+  val config: Config = ConfigFactory.parseString("""
+    pekko.persistence.r2dbc.connection-factory {
+      options-customizer = "org.apache.pekko.persistence.r2dbc.OptionsCustomizerSpec$Customizer"
+    }
+    """).withFallback(TestConfig.config)
+}

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettingsSpec.scala
@@ -62,5 +62,13 @@ class R2dbcSettingsSpec extends AnyWordSpec with TestSuite with Matchers {
       settings.connectionFactorySettings.sslMode shouldBe "verify-full"
       SSLMode.fromValue(settings.connectionFactorySettings.sslMode) shouldBe SSLMode.VERIFY_FULL
     }
+
+    "allow to specify options customizer" in {
+      val config = ConfigFactory
+        .parseString("pekko.persistence.r2dbc.connection-factory.options-customizer=fqcn")
+        .withFallback(ConfigFactory.load())
+      val settings = R2dbcSettings(config.getConfig("pekko.persistence.r2dbc"))
+      settings.connectionFactorySettings.optionsCustomizer shouldBe Some("fqcn")
+    }
   }
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettingsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettingsSpec.scala
@@ -63,12 +63,12 @@ class R2dbcSettingsSpec extends AnyWordSpec with TestSuite with Matchers {
       SSLMode.fromValue(settings.connectionFactorySettings.sslMode) shouldBe SSLMode.VERIFY_FULL
     }
 
-    "allow to specify options customizer" in {
+    "allow to specify ConnectionFactoryOptions customizer" in {
       val config = ConfigFactory
-        .parseString("pekko.persistence.r2dbc.connection-factory.options-customizer=fqcn")
+        .parseString("pekko.persistence.r2dbc.connection-factory.connection-factory-options-customizer=fqcn")
         .withFallback(ConfigFactory.load())
       val settings = R2dbcSettings(config.getConfig("pekko.persistence.r2dbc"))
-      settings.connectionFactorySettings.optionsCustomizer shouldBe Some("fqcn")
+      settings.connectionFactorySettings.connectionFactoryOptionsCustomizer shouldBe Some("fqcn")
     }
   }
 }


### PR DESCRIPTION
Resolves #169

Adds a new configuration setting, `connection-factory.connection-factory-options-customizer`, which can contain the FQCN of a class that implements the ConnectionFactoryOptionsCustomizer trait. This class must have a constructor that accepts a single parameter of type ActorSystem[_]. If this setting is specified, ConnectionFactoryProvider will instantiate the customizer and use it to augment the connection factory options just before the factory is created.