### PR TITLE
make r2dbc-postgresql dependency 'provided'

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,8 +34,7 @@ object Dependencies {
 
     val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "1.0.0.RELEASE"
     val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "1.0.2.RELEASE"
-    val r2dbcPostgres = Seq(
-      "org.postgresql" % "r2dbc-postgresql" % "1.0.7.RELEASE")
+    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "1.0.7.RELEASE"
     val r2dbcMysql = "io.asyncer" % "r2dbc-mysql" % "1.3.0"
   }
 
@@ -76,18 +75,20 @@ object Dependencies {
     pekkoPersistenceQuery,
     r2dbcSpi,
     r2dbcPool,
+    r2dbcPostgres % "provided,test",
     r2dbcMysql % "provided,test",
     TestDeps.pekkoPersistenceTck,
     TestDeps.pekkoStreamTestkit,
     TestDeps.pekkoActorTestkitTyped,
     TestDeps.pekkoJackson,
     TestDeps.logback,
-    TestDeps.scalaTest) ++ r2dbcPostgres
+    TestDeps.scalaTest)
 
   val projection = Seq(
     pekkoPersistenceQuery,
     r2dbcSpi,
     r2dbcPool,
+    r2dbcPostgres % "provided,test",
     pekkoProjectionCore,
     TestDeps.pekkoProjectionEventSourced,
     TestDeps.pekkoProjectionDurableState,
@@ -96,7 +97,7 @@ object Dependencies {
     TestDeps.pekkoJackson,
     TestDeps.pekkoStreamTestkit,
     TestDeps.logback,
-    TestDeps.scalaTest) ++ r2dbcPostgres
+    TestDeps.scalaTest)
 
   val migration = Seq(
     "org.apache.pekko" %% "pekko-persistence-jdbc" % PekkoPersistenceJdbcVersion % Test,


### PR DESCRIPTION
* relates to #170 
* idea is that it should be ok in a minor release like 1.1.0 to change the r2dbc-postgresql dependency to provided
* if we add support for another db product then its r2dbc jar would also be 'provided'