### PR TITLE
fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Version 1.0.0 has been released. Any contributions are welcome. Please observe t
 
 There are several ways to interact with the Pekko community:
 
-- [GitHub discussions](https://github.com/apache/pekko-persistence-jdbc/discussions): for questions and general discussion.
+- [GitHub discussions](https://github.com/apache/pekko-persistence-r2dbc/discussions): for questions and general discussion.
 - [Pekko dev mailing list](https://lists.apache.org/list.html?dev@pekko.apache.org): for Pekko development discussions.
 - [Pekko users mailing list](https://lists.apache.org/list.html?users@pekko.apache.org): for Pekko user discussions.
 - [GitHub issues](https://github.com/apache/pekko-persistence-r2dbc/issues): for bug reports and feature requests. Please search the existing issues before creating new ones. If you are unsure whether you have found a bug, consider asking in GitHub discussions or the mailing list first.


### PR DESCRIPTION
accidentally points to pekko-persistence-jdbc link but should be to this repo