### PR TITLE
Change pekko dependency to 1.2.0

### DIFF
--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.1.5"
+  override val currentVersion: String = "1.2.0"
 }


### PR DESCRIPTION
The main branch code relies on changes in Pekko 1.1.3. It is tidier to depend on the full 1.2.0 release which has the changes too.