### PR TITLE
pekko 1.2.1

### DIFF
--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.2.0"
+  override val currentVersion: String = "1.2.1"
 }


### PR DESCRIPTION
this is the only repo where we have an explicit dependency on pekko 1.2