### PR TITLE
remove warning from doc

### DIFF
--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -8,13 +8,6 @@ It is specifically designed to work well for distributed SQL databases.
 [Create an issue](https://github.com/apache/pekko-persistence-r2dbc/issues) if you would like to @ref[contribute](contributing.md)
 support for other databases that has a [R2DBC driver](https://r2dbc.io/drivers/).
 
-@@@ warning
-
-The project is currently under development and there are no guarantees for binary compatibility
-and the schema may change.
-
-@@@
-
 ## Project Info
 
 @@project-info{ projectId="core" }


### PR DESCRIPTION
Akka removed this 3 years ago in 1.0.1 (now Apache licensed change - #302).
I think we can say that in Pekko 2.0.0, at least, that we can guarantee some stability.