### PR TITLE
Port akka-persistence-r2dbc#365: support ?? as escaped ? in SQL interpolation

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/Sql.scala
@@ -42,8 +42,9 @@ object Sql {
   }
 
   /**
-   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Trims
-   * whitespace, including line breaks. Standard string interpolation arguments `$` can be used.
+   * Scala string interpolation with `sql` prefix. Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??`
+   * to include a literal `?`. Trims whitespace, including line breaks. Standard string interpolation arguments `$` can
+   * be used.
    */
   implicit class Interpolation(val sc: StringContext) extends AnyVal {
     def sql(args: Any*): String =
@@ -60,8 +61,8 @@ object Sql {
   }
 
   /**
-   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Trims whitespace, including line breaks. The
-   * arguments are used like in [[java.lang.String.format]].
+   * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??` to include a literal `?`. Trims
+   * whitespace, including line breaks. The arguments are used like in [[java.lang.String.format]].
    */
   @varargs
   def format(sql: String, args: AnyRef*): String =
@@ -74,9 +75,13 @@ object Sql {
       val sb = new java.lang.StringBuilder(sql.length + 10)
       var n = 0
       var i = 0
+      def isNext(d: Char): Boolean = (i < sql.length - 1) && (sql.charAt(i + 1) == d)
       while (i < sql.length) {
         val c = sql.charAt(i)
-        if (c == '?') {
+        if (c == '?' && isNext('?')) {
+          sb.append('?')
+          i += 1 // advance past extra '?'
+        } else if (c == '?') {
           n += 1
           sb.append('$').append(n)
         } else {

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/internal/SqlSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/internal/SqlSpec.scala
@@ -21,10 +21,9 @@ class SqlSpec extends AnyWordSpec with TestSuite with Matchers {
   import Sql.Interpolation
 
   "SQL string interpolation" should {
-    "replace ? bind parameters with numbered $" in {
-      sql"select * from bar where a = ?" shouldBe "select * from bar where a = $1"
-      sql"select * from bar where a = ? and b = ? and c = ?" shouldBe
-      "select * from bar where a = $1 and b = $2 and c = $3"
+    "replace ? bind parameters with numbered $ (avoiding escaped ones)" in {
+      sql"select * from bar where a = ? and qa = 'Question?? Answer!'" shouldBe "select * from bar where a = $1 and qa = 'Question? Answer!'"
+      sql"select * from bar where a = ? and b = ? and jsonb ?? 'status' and c = ?" shouldBe "select * from bar where a = $1 and b = $2 and jsonb ? 'status' and c = $3"
       sql"select * from bar" shouldBe "select * from bar"
     }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/internal/SqlSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/internal/SqlSpec.scala
@@ -22,8 +22,10 @@ class SqlSpec extends AnyWordSpec with TestSuite with Matchers {
 
   "SQL string interpolation" should {
     "replace ? bind parameters with numbered $ (avoiding escaped ones)" in {
-      sql"select * from bar where a = ? and qa = 'Question?? Answer!'" shouldBe "select * from bar where a = $1 and qa = 'Question? Answer!'"
-      sql"select * from bar where a = ? and b = ? and jsonb ?? 'status' and c = ?" shouldBe "select * from bar where a = $1 and b = $2 and jsonb ? 'status' and c = $3"
+      sql"select * from bar where a = ? and qa = 'Question?? Answer!'" shouldBe
+      "select * from bar where a = $1 and qa = 'Question? Answer!'"
+      sql"select * from bar where a = ? and b = ? and jsonb ?? 'status' and c = ?" shouldBe
+      "select * from bar where a = $1 and b = $2 and jsonb ? 'status' and c = $3"
       sql"select * from bar" shouldBe "select * from bar"
     }
 


### PR DESCRIPTION
Ports https://github.com/akka/akka-persistence-r2dbc/pull/365 to this repo.

Part of https://github.com/akka/akka-persistence-r2dbc/releases/tag/v1.1.0 which is now available under Apache License v2.0

## Summary

Adds support for `??` as an escape sequence to produce a literal `?` in SQL strings built with the `sql` interpolator or `Sql.format`. This is useful for PostgreSQL JSON/JSONB operators (e.g. `jsonb ?? 'key'`) which use `?` in their syntax but should not be treated as bind parameter placeholders.

## Changes

- **`Sql.scala`**: In `fillInParameterNumbers`, handle `??` by emitting a single `?` and skipping the second character. Updated Scaladoc for `Interpolation` and `format` to document the new escape.
- **`SqlSpec.scala`**: Updated test case to verify `??` is correctly treated as a literal `?` and does not affect bind parameter numbering.
