### PR TITLE
feat: allow client certificates for SSL connections to be configured

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -174,8 +174,17 @@ pekko.persistence.r2dbc {
       #  tunnel - use a SSL tunnel instead of following Postgres SSL handshake protocol
       mode = ""
 
-      # Can point to either a resource within the classpath or a file.
+      # Server root certificate. Can point to either a resource within the classpath or a file.
       root-cert = ""
+
+      # Client certificate. Can point to either a resource within the classpath or a file.
+      cert = ""
+
+      # Key for client certificate. Can point to either a resource within the classpath or a file.
+      key = ""
+
+      # Password for client key.
+      password = ""
     }
 
     # Initial pool size.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -155,6 +155,15 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
 
       if (settings.sslRootCert.nonEmpty)
         builder.option(PostgresqlConnectionFactoryProvider.SSL_ROOT_CERT, settings.sslRootCert)
+
+      if (settings.sslCert.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_CERT, settings.sslCert)
+
+      if (settings.sslKey.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_KEY, settings.sslKey)
+
+      if (settings.sslPassword.nonEmpty)
+        builder.option(PostgresqlConnectionFactoryProvider.SSL_PASSWORD, settings.sslPassword)
     }
 
     if (settings.driver == "mysql") {

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -252,6 +252,9 @@ final class ConnectionFactorySettings(config: Config) {
   val sslEnabled: Boolean = config.getBoolean("ssl.enabled")
   val sslMode: String = config.getString("ssl.mode")
   val sslRootCert: String = config.getString("ssl.root-cert")
+  val sslCert: String = config.getString("ssl.cert")
+  val sslKey: String = config.getString("ssl.key")
+  val sslPassword: String = config.getString("ssl.password")
 
   val initialSize: Int = config.getInt("initial-size")
   val maxSize: Int = config.getInt("max-size")


### PR DESCRIPTION
Port of [akka/akka-persistence-r2dbc#391](https://github.com/akka/akka-persistence-r2dbc/pull/391).

part of https://github.com/akka/akka-persistence-r2dbc/releases/tag/v1.1.0 which is now available under Apache License version 2.0

Allow client certificates for SSL connections to be configured by passing more of the PostgreSQL connection options.

## Changes

- `reference.conf`: added `cert`, `key`, and `password` fields under the `ssl` section with documentation comments
- `R2dbcSettings.scala`: added `sslCert`, `sslKey`, and `sslPassword` vals to `ConnectionFactorySettings`
- `ConnectionFactoryProvider.scala`: pass the three new SSL options (`SSL_CERT`, `SSL_KEY`, `SSL_PASSWORD`) to the connection factory builder when non-empty
