### PR TITLE
Port akka/akka-persistence-r2dbc#346: add currentPersistenceIds by entity type

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -94,6 +94,26 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
   override def currentPersistenceIds(afterId: Optional[String], limit: Long): Source[String, NotUsed] =
     delegate.currentPersistenceIds(afterId.toScala, limit).asJava
 
+  /**
+   * Get the current persistence ids.
+   *
+   * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
+   * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
+   * [[pekko.persistence.typed.PersistenceId]].
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param afterId
+   *   The ID to start returning results from, or empty to return all ids. This should be an id returned from a previous
+   *   invocation of this command. Callers should not assume that ids are returned in sorted order.
+   * @param limit
+   *   The maximum results to return. Use Long.MAX_VALUE to return all results. Must be greater than zero.
+   * @return
+   *   A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(entityType: String, afterId: Optional[String], limit: Long): Source[String, NotUsed] =
+    delegate.currentPersistenceIds(entityType, afterId.toScala, limit).asJava
+
   override def timestampOf(persistenceId: String, sequenceNr: Long): CompletionStage[Optional[Instant]] =
     delegate.timestampOf(persistenceId, sequenceNr).map(_.toJava)(ExecutionContext.parasitic).asJava
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -36,6 +36,7 @@ import pekko.persistence.r2dbc.internal.Sql.DialectInterpolation
 import pekko.persistence.r2dbc.journal.JournalDao
 import pekko.persistence.r2dbc.journal.JournalDao.SerializedJournalRow
 import pekko.persistence.r2dbc.query.scaladsl.mysql.MySQLQueryDao
+import pekko.persistence.typed.PersistenceId
 import pekko.stream.scaladsl.Source
 import com.typesafe.config.Config
 import io.r2dbc.spi.ConnectionFactory
@@ -143,8 +144,14 @@ private[r2dbc] class QueryDao(val settings: QuerySettings, connectionFactory: Co
   private val allPersistenceIdsSql =
     sql"SELECT DISTINCT(persistence_id) from $journalTable ORDER BY persistence_id LIMIT ?"
 
+  private val persistenceIdsForEntityTypeSql =
+    sql"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id LIKE ? ORDER BY persistence_id LIMIT ?"
+
   private val allPersistenceIdsAfterSql =
     sql"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id > ? ORDER BY persistence_id LIMIT ?"
+
+  private val persistenceIdsForEntityTypeAfterSql =
+    sql"SELECT DISTINCT(persistence_id) from $journalTable WHERE persistence_id LIKE ? AND persistence_id > ? ORDER BY persistence_id LIMIT ?"
 
   protected val r2dbcExecutor =
     new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(ec, system)
@@ -304,6 +311,31 @@ private[r2dbc] class QueryDao(val settings: QuerySettings, connectionFactory: Co
           writerUuid = "", // not need in this query
           tags = Set.empty, // tags not fetched in queries (yet)
           metadata = readMetadata(row)))
+
+  def persistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] = {
+    val likeStmtPostfix = PersistenceId.DefaultSeparator + "%"
+    val result = r2dbcExecutor.select(s"select persistenceIds by entity type")(
+      connection =>
+        afterId match {
+          case Some(after) =>
+            connection
+              .createStatement(persistenceIdsForEntityTypeAfterSql)
+              .bind(0, entityType + likeStmtPostfix)
+              .bind(1, after)
+              .bind(2, limit)
+          case None =>
+            connection
+              .createStatement(persistenceIdsForEntityTypeSql)
+              .bind(0, entityType + likeStmtPostfix)
+              .bind(1, limit)
+        },
+      row => row.get("persistence_id", classOf[String]))
+
+    if (log.isDebugEnabled)
+      result.foreach(rows => log.debug("Read [{}] persistence ids by entity type [{}]", rows.size, entityType))
+
+    Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
+  }
 
   def persistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] = {
     val result = r2dbcExecutor.select(s"select persistenceIds")(

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -345,6 +345,26 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
   override def currentPersistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] =
     queryDao.persistenceIds(afterId, limit)
 
+  /**
+   * Get the current persistence ids.
+   *
+   * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
+   * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
+   * [[pekko.persistence.typed.PersistenceId]].
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param afterId
+   *   The ID to start returning results from, or [[None]] to return all ids. This should be an id returned from a
+   *   previous invocation of this command. Callers should not assume that ids are returned in sorted order.
+   * @param limit
+   *   The maximum results to return. Use Long.MaxValue to return all results. Must be greater than zero.
+   * @return
+   *   A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] =
+    queryDao.persistenceIds(entityType, afterId, limit)
+
   override def currentPersistenceIds(): Source[String, NotUsed] = {
     import settings.persistenceIdsBufferSize
     def updateState(state: PersistenceIdsQueryState, pid: String): PersistenceIdsQueryState =

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
@@ -87,6 +87,28 @@ class R2dbcDurableStateStore[A](scalaStore: ScalaR2dbcDurableStateStore[A])(impl
     scalaStore.currentPersistenceIds(afterId.toScala, limit).asJava
   }
 
+  /**
+   * Get the current persistence ids.
+   *
+   * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
+   * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
+   * [[pekko.persistence.typed.PersistenceId]].
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param afterId
+   *   The ID to start returning results from, or empty to return all ids. This should be an id returned from a previous
+   *   invocation of this command. Callers should not assume that ids are returned in sorted order.
+   * @param limit
+   *   The maximum results to return. Use Long.MAX_VALUE to return all results. Must be greater than zero.
+   * @return
+   *   A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(entityType: String, afterId: Optional[String], limit: Long): Source[String, NotUsed] = {
+    import scala.jdk.OptionConverters._
+    scalaStore.currentPersistenceIds(entityType, afterId.toScala, limit).asJava
+  }
+
   def currentPersistenceIds(): Source[String, NotUsed] =
     scalaStore.currentPersistenceIds().asJava
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -160,8 +160,14 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   private val allPersistenceIdsSql =
     sql"SELECT persistence_id from $stateTable ORDER BY persistence_id LIMIT ?"
 
+  private val persistenceIdsForEntityTypeSql =
+    sql"SELECT persistence_id from $stateTable WHERE persistence_id LIKE ? ORDER BY persistence_id LIMIT ?"
+
   private val allPersistenceIdsAfterSql =
     sql"SELECT persistence_id from $stateTable WHERE persistence_id > ? ORDER BY persistence_id LIMIT ?"
+
+  private val persistenceIdsForEntityTypeAfterSql =
+    sql"SELECT persistence_id from $stateTable WHERE persistence_id LIKE ? AND persistence_id > ? ORDER BY persistence_id LIMIT ?"
 
   protected def stateBySlicesRangeSql(
       maxDbTimestampParam: Boolean,
@@ -460,6 +466,31 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
         log.debug("Read [{}] durable states from slices [{} - {}]", rows.size: java.lang.Integer,
           minSlice: java.lang.Integer,
           maxSlice: java.lang.Integer))
+
+    Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
+  }
+
+  def persistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] = {
+    val likeStmtPostfix = PersistenceId.DefaultSeparator + "%"
+    val result = r2dbcExecutor.select(s"select persistenceIds by entity type")(
+      connection =>
+        afterId match {
+          case Some(after) =>
+            connection
+              .createStatement(persistenceIdsForEntityTypeAfterSql)
+              .bind(0, entityType + likeStmtPostfix)
+              .bind(1, after)
+              .bind(2, limit)
+          case None =>
+            connection
+              .createStatement(persistenceIdsForEntityTypeSql)
+              .bind(0, entityType + likeStmtPostfix)
+              .bind(1, limit)
+        },
+      row => row.get("persistence_id", classOf[String]))
+
+    if (log.isDebugEnabled)
+      result.foreach(rows => log.debug("Read [{}] persistence ids by entity type [{}]", rows.size, entityType))
 
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -174,6 +174,26 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
   override def currentPersistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] =
     stateDao.persistenceIds(afterId, limit)
 
+  /**
+   * Get the current persistence ids.
+   *
+   * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
+   * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
+   * [[pekko.persistence.typed.PersistenceId]].
+   *
+   * @param entityType
+   *   The entity type name.
+   * @param afterId
+   *   The ID to start returning results from, or [[None]] to return all ids. This should be an id returned from a
+   *   previous invocation of this command. Callers should not assume that ids are returned in sorted order.
+   * @param limit
+   *   The maximum results to return. Use Long.MaxValue to return all results. Must be greater than zero.
+   * @return
+   *   A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(entityType: String, afterId: Option[String], limit: Long): Source[String, NotUsed] =
+    stateDao.persistenceIds(entityType, afterId, limit)
+
   def currentPersistenceIds(): Source[String, NotUsed] = {
     import settings.persistenceIdsBufferSize
     def updateState(state: PersistenceIdsQueryState, pid: String): PersistenceIdsQueryState =

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
@@ -49,9 +49,14 @@ class CurrentPersistenceIdsQuerySpec
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 
   private val zeros = "0000"
-  private val entityType = nextEntityType()
+  private val numberOfEntityTypes = 5
+  private val entityTypes = (1 to numberOfEntityTypes).map(_ => nextEntityType())
   private val numberOfPids = 100
-  private val pids = (1 to numberOfPids).map(n => PersistenceId(entityType, "p" + zeros.drop(n.toString.length) + n))
+  private val pids = {
+    (1 to numberOfEntityTypes).flatMap(entityTypeId =>
+      (1 to numberOfPids / numberOfEntityTypes).map(n =>
+        PersistenceId(entityTypes(entityTypeId - 1), "p" + zeros.drop(n.toString.length) + n)))
+  }
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -73,9 +78,27 @@ class CurrentPersistenceIdsQuerySpec
       result shouldBe pids.map(_.id)
     }
 
-    "retrieve ids afterId" in {
+    "retrieve ids after id" in {
       val result = query.currentPersistenceIds(afterId = Some(pids(9).id), limit = 7).runWith(Sink.seq).futureValue
       result shouldBe pids.slice(10, 17).map(_.id)
+    }
+
+    "retrieve ids for entity type" in {
+      val entityType = entityTypes(1)
+      val result =
+        query.currentPersistenceIds(entityType = entityType, afterId = None, limit = 30).runWith(Sink.seq).futureValue
+      result shouldBe pids.filter(_.entityTypeHint == entityType).map(_.id)
+    }
+
+    "retrieve ids for entity type after id" in {
+      val entityType = entityTypes(0)
+      val result =
+        query
+          .currentPersistenceIds(entityType = entityType, afterId = Some(pids(9).id), limit = 7)
+          .runWith(Sink.seq)
+          .futureValue
+
+      result shouldBe pids.filter(_.entityTypeHint == entityType).slice(10, 17).map(_.id)
     }
 
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
@@ -50,9 +50,15 @@ class CurrentPersistenceIdsQuerySpec
     .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)
 
   private val zeros = "0000"
-  private val entityType = nextEntityType()
+  private val numberOfEntityTypes = 5
+  private val entityTypes = (1 to numberOfEntityTypes).map(_ => nextEntityType())
   private val numberOfPids = 100
-  private val pids = (1 to numberOfPids).map(n => PersistenceId(entityType, "p" + zeros.drop(n.toString.length) + n))
+
+  private val pids = {
+    (1 to numberOfEntityTypes).flatMap(entityTypeId =>
+      (1 to numberOfPids / numberOfEntityTypes).map(n =>
+        PersistenceId(entityTypes(entityTypeId - 1), "p" + zeros.drop(n.toString.length) + n)))
+  }
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -76,6 +82,24 @@ class CurrentPersistenceIdsQuerySpec
     "retrieve ids afterId" in {
       val result = store.currentPersistenceIds(afterId = Some(pids(9).id), limit = 7).runWith(Sink.seq).futureValue
       result shouldBe pids.slice(10, 17).map(_.id)
+    }
+
+    "retrieve ids for entity type" in {
+      val entityType = entityTypes(1)
+      val result =
+        store.currentPersistenceIds(entityType = entityType, afterId = None, limit = 30).runWith(Sink.seq).futureValue
+      result shouldBe pids.filter(_.entityTypeHint == entityType).map(_.id)
+    }
+
+    "retrieve ids for entity type after id" in {
+      val entityType = entityTypes(0)
+      val result =
+        store
+          .currentPersistenceIds(entityType = entityType, afterId = Some(pids(9).id), limit = 7)
+          .runWith(Sink.seq)
+          .futureValue
+
+      result shouldBe pids.filter(_.entityTypeHint == entityType).slice(10, 17).map(_.id)
     }
 
   }


### PR DESCRIPTION
## Summary

Ports https://github.com/akka/akka-persistence-r2dbc/pull/346 to this repository.

Part of https://github.com/akka/akka-persistence-r2dbc/releases/tag/v1.1.0 which is now available under Apache License v2.0

Adds `currentPersistenceIds(entityType, afterId, limit)` methods that allow querying persistence IDs filtered by entity type, using a SQL `LIKE` clause on the `persistence_id` column.

> **Note:** To reuse the existing index, the actual query filters entity types based on the `persistence_id` column and the SQL `LIKE` operator. Hence the `persistenceId` must start with an entity type followed by the default separator (`"|"`) from `PersistenceId`.

## Changes

- `QueryDao`: new SQL queries (`persistenceIdsForEntityTypeSql`, `persistenceIdsForEntityTypeAfterSql`) and new overloaded `persistenceIds(entityType, afterId, limit)` method
- `scaladsl/R2dbcReadJournal`: new `currentPersistenceIds(entityType, afterId, limit)` method
- `javadsl/R2dbcReadJournal`: new `currentPersistenceIds(entityType, afterId, limit)` method (using `Optional[String]`)
- `DurableStateDao`: same SQL queries and overloaded `persistenceIds` method for durable state
- `scaladsl/R2dbcDurableStateStore`: new `currentPersistenceIds(entityType, afterId, limit)` method
- `javadsl/R2dbcDurableStateStore`: new `currentPersistenceIds(entityType, afterId, limit)` method
- Both `CurrentPersistenceIdsQuerySpec` test files updated with tests for multiple entity types, "retrieve ids for entity type" and "retrieve ids for entity type after id" scenarios