### PR TITLE
pekko 2 based build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ sourceDistIncubating := false
 
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
+ThisBuild / evictionErrorLevel := Level.Info
 
 GlobalScope / parallelExecution := false
 Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.3.0"
+  override val currentVersion: String = "2.0.0-M2"
 }

--- a/project/PekkoPersistenceJdbcDependency.scala
+++ b/project/PekkoPersistenceJdbcDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoPersistenceJdbcDependency extends PekkoDependency {
   override val checkProject: String = "pekko-persistence-jdbc"
   override val module: Option[String] = Some("persistence.jdbc")
-  override val currentVersion: String = "1.1.1"
+  override val currentVersion: String = "2.0.0-M1"
 }

--- a/project/PekkoProjectionDependency.scala
+++ b/project/PekkoProjectionDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoProjectionDependency extends PekkoDependency {
   override val checkProject: String = "pekko-projection-jdbc"
   override val module: Option[String] = Some("projection")
-  override val currentVersion: String = "1.1.0"
+  override val currentVersion: String = "2.0.0-M0+150-2746ce4b-SNAPSHOT"
 }

--- a/project/PekkoProjectionDependency.scala
+++ b/project/PekkoProjectionDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoProjectionDependency extends PekkoDependency {
   override val checkProject: String = "pekko-projection-jdbc"
   override val module: Option[String] = Some("projection")
-  override val currentVersion: String = "2.0.0-M0+150-2746ce4b-SNAPSHOT"
+  override val currentVersion: String = "2.0.0-M0+151-2799a92a-SNAPSHOT"
 }


### PR DESCRIPTION
this is needed to proceed with getting akka-persistence-r2dbc updates - which rely on changes that are only in pekko 2 

also, we need to get towards having a v2 release of this module

the dependency on a snapshot of pekko-projection is temporary - we should hopefully be able to do a 2.0.0-M1 release of that module in a few weeks

the link validator issue is because of the pekko-projection snapshot but this is a dev branch and we can afford to break the docs temporarily on a branch that doesn't affect our production docs