### PR TITLE
Add Cleanup tool ported from akka PRs #326 and #329

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -155,6 +155,18 @@ pekko.persistence.r2dbc {
 }
 // #query-settings
 
+pekko.persistence.r2dbc {
+  # Configuration of the Cleanup tool.
+  cleanup {
+    # Log progress after this number of delete operations. Can be set to 1 to log
+    # progress of each operation.
+    log-progress-every = 100
+    # For large journals deleting events in a single transaction might not be very efficient.
+    # Set this value to expected delete batch size to minimize table lock holding and contention.
+    events-journal-delete-batch-size = 1000
+  }
+}
+
 // #connection-settings
 pekko.persistence.r2dbc {
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -300,3 +300,12 @@ final class PublishEventsDynamicSettings(config: Config) {
   val throughputThreshold: Int = config.getInt("throughput-threshold")
   val throughputCollectInterval: FiniteDuration = config.getDuration("throughput-collect-interval").toScala
 }
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+final class CleanupSettings(config: Config) {
+  val logProgressEvery: Int = config.getInt("log-progress-every")
+  val eventsJournalDeleteBatchSize: Int = config.getInt("events-journal-delete-batch-size")
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/javadsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/javadsl/DurableStateCleanup.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.persistence.r2dbc.cleanup.javadsl
+
+import java.util.concurrent.CompletionStage
+import java.util.{ List => JList }
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ClassicActorSystemProvider
+import pekko.annotation.ApiMayChange
+import pekko.persistence.r2dbc.cleanup.{ scaladsl => sd }
+
+/**
+ * Java API: Tool for deleting durable state for a given list of `persistenceIds` without using `DurableStateBehavior`
+ * actors. It's important that the actors with corresponding persistenceId are not running at the same time as using the
+ * tool.
+ *
+ * If `resetRevisionNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used revision number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the revision number should be avoided, since it might be
+ * confusing to reuse the same revision numbers for new state changes.
+ *
+ * When a list of `persistenceIds` are given they are deleted sequentially in the order of the list. It's possible to
+ * parallelize the deletes by running several cleanup operations at the same time operating on different sets of
+ * `persistenceIds`.
+ */
+@ApiMayChange
+final class DurableStateCleanup private (delegate: sd.DurableStateCleanup) {
+
+  def this(systemProvider: ClassicActorSystemProvider, configPath: String) =
+    this(new sd.DurableStateCleanup(systemProvider, configPath))
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "pekko.persistence.r2dbc.cleanup")
+
+  /**
+   * Delete the state related to one single `persistenceId`.
+   */
+  def deleteState(persistenceId: String, resetRevisionNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteState(persistenceId, resetRevisionNumber).asJava
+
+  /**
+   * Delete all states related to the given list of `persistenceIds`.
+   */
+  def deleteStates(persistenceIds: JList[String], resetRevisionNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteStates(persistenceIds.asScala.toVector, resetRevisionNumber).asJava
+
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/javadsl/EventSourcedCleanup.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.persistence.r2dbc.cleanup.javadsl
+
+import java.util.concurrent.CompletionStage
+import java.util.{ List => JList }
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ClassicActorSystemProvider
+import pekko.annotation.ApiMayChange
+import pekko.persistence.r2dbc.cleanup.{ scaladsl => sd }
+
+/**
+ * Java API: Tool for deleting all events and/or snapshots for a given list of `persistenceIds` without using persistent
+ * actors. It's important that the actors with corresponding `persistenceId` are not running at the same time as using
+ * the tool.
+ *
+ * WARNING: deleting events is generally discouraged in event sourced systems.
+ *
+ * If `resetSequenceNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ *
+ * When a list of `persistenceIds` are given they are deleted sequentially in the order of the list. It's possible to
+ * parallelize the deletes by running several cleanup operations at the same time operating on different sets of
+ * `persistenceIds`.
+ */
+@ApiMayChange
+final class EventSourcedCleanup private (delegate: sd.EventSourcedCleanup) {
+
+  def this(systemProvider: ClassicActorSystemProvider, configPath: String) =
+    this(new sd.EventSourcedCleanup(systemProvider, configPath))
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "pekko.persistence.r2dbc.cleanup")
+
+  /**
+   * Delete all events before a sequenceNr for the given persistence id. Snapshots are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param toSequenceNr
+   *   sequence nr (inclusive) to delete up to
+   */
+  def deleteEventsTo(persistenceId: String, toSequenceNr: Long): CompletionStage[Done] =
+    delegate.deleteEventsTo(persistenceId, toSequenceNr).asJava
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAllEvents(persistenceId, resetSequenceNumber).asJava
+
+  /**
+   * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAllEvents(persistenceIds.asScala.toVector, resetSequenceNumber).asJava
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): CompletionStage[Done] =
+    delegate.deleteSnapshot(persistenceId).asJava
+
+  /**
+   * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
+   */
+  def deleteSnapshots(persistenceIds: JList[String]): CompletionStage[Done] =
+    delegate.deleteSnapshots(persistenceIds.asScala.toVector).asJava
+
+  /**
+   * Deletes all events for the given persistence id from before the snapshot. The snapshot is not deleted. The event
+   * with the same sequence number as the remaining snapshot is deleted.
+   */
+  def cleanupBeforeSnapshot(persistenceId: String): CompletionStage[Done] =
+    delegate.cleanupBeforeSnapshot(persistenceId).asJava
+
+  /**
+   * See single persistenceId overload for what is done for each persistence id
+   */
+  def cleanupBeforeSnapshot(persistenceIds: JList[String]): CompletionStage[Done] =
+    delegate.cleanupBeforeSnapshot(persistenceIds.asScala.toVector).asJava
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAll(persistenceId, resetSequenceNumber).asJava
+
+  /**
+   * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceIds: JList[String], resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAll(persistenceIds.asScala.toVector, resetSequenceNumber).asJava
+
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -105,7 +105,7 @@ final class DurableStateCleanup(systemProvider: ClassicActorSystemProvider, conf
 
     def loop(remaining: List[String], n: Int): Future[Done] = {
       remaining match {
-        case Nil => Future.successful(Done)
+        case Nil         => Future.successful(Done)
         case pid :: tail =>
           pidOperation(pid).flatMap { _ =>
             if (n % cleanupSettings.logProgressEvery == 0)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.persistence.r2dbc.cleanup.scaladsl
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ClassicActorSystemProvider
+import pekko.actor.typed.ActorSystem
+import pekko.actor.typed.scaladsl.LoggerOps
+import pekko.actor.typed.scaladsl.adapter._
+import pekko.annotation.ApiMayChange
+import pekko.annotation.InternalApi
+import pekko.persistence.r2dbc.CleanupSettings
+import pekko.persistence.r2dbc.ConnectionFactoryProvider
+import pekko.persistence.r2dbc.StateSettings
+import pekko.persistence.r2dbc.state.scaladsl.DurableStateDao
+import org.slf4j.LoggerFactory
+
+/**
+ * Scala API: Tool for deleting durable state for a given list of `persistenceIds` without using `DurableStateBehavior`
+ * actors. It's important that the actors with corresponding persistenceId are not running at the same time as using the
+ * tool.
+ *
+ * If `resetRevisionNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used revision number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the revision number should be avoided, since it might be
+ * confusing to reuse the same revision numbers for new state changes.
+ *
+ * When a list of `persistenceIds` are given they are deleted sequentially in the order of the list. It's possible to
+ * parallelize the deletes by running several cleanup operations at the same time operating on different sets of
+ * `persistenceIds`.
+ */
+@ApiMayChange
+final class DurableStateCleanup(systemProvider: ClassicActorSystemProvider, configPath: String) {
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "pekko.persistence.r2dbc.cleanup")
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[pekko] implicit val system: ActorSystem[_] =
+    systemProvider.classicSystem.toTyped
+
+  import system.executionContext
+
+  private val log = LoggerFactory.getLogger(classOf[DurableStateCleanup])
+
+  private val sharedConfigPath = configPath.replaceAll("""\.cleanup$""", "")
+  private val settings = system.settings.config
+
+  private val cleanupSettings =
+    new CleanupSettings(settings.getConfig(sharedConfigPath + ".cleanup"))
+  private val stateSettings =
+    StateSettings(settings.getConfig(sharedConfigPath + ".state"))
+
+  private val connectionFactory =
+    ConnectionFactoryProvider(system).connectionFactoryFor(sharedConfigPath + ".connection-factory")
+  private val stateDao = new DurableStateDao(stateSettings, connectionFactory)
+
+  /**
+   * Delete the state related to one single `persistenceId`.
+   */
+  def deleteState(persistenceId: String, resetRevisionNumber: Boolean): Future[Done] = {
+    if (resetRevisionNumber)
+      stateDao.deleteStateForRevision(persistenceId, revision = 0L).map(_ => Done)
+    else {
+      stateDao.readState(persistenceId).flatMap {
+        case None    => Future.successful(Done)
+        case Some(s) => stateDao.deleteStateForRevision(persistenceId, s.revision + 1).map(_ => Done)
+      }
+    }
+  }
+
+  /**
+   * Delete all states related to the given list of `persistenceIds`.
+   */
+  def deleteStates(persistenceIds: immutable.Seq[String], resetRevisionNumber: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteStates", pid => deleteState(pid, resetRevisionNumber))
+  }
+
+  private def foreach(
+      persistenceIds: immutable.Seq[String],
+      operationName: String,
+      pidOperation: String => Future[Done]): Future[Done] = {
+    val size = persistenceIds.size
+    log.info("Cleanup started {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
+
+    def loop(remaining: List[String], n: Int): Future[Done] = {
+      remaining match {
+        case Nil => Future.successful(Done)
+        case pid :: tail =>
+          pidOperation(pid).flatMap { _ =>
+            if (n % cleanupSettings.logProgressEvery == 0)
+              log.infoN("Cleanup {} [{}] of [{}].", operationName, n: java.lang.Integer, size: java.lang.Integer)
+            loop(tail, n + 1)
+          }
+      }
+    }
+
+    val result = loop(persistenceIds.toList, n = 1)
+
+    result.onComplete {
+      case Success(_) =>
+        log.info2("Cleanup completed {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
+      case Failure(e) =>
+        log.error(s"Cleanup {$operationName} failed.", e)
+    }
+
+    result
+  }
+
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -121,7 +121,7 @@ final class DurableStateCleanup(systemProvider: ClassicActorSystemProvider, conf
       case Success(_) =>
         log.info2("Cleanup completed {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
       case Failure(e) =>
-        log.error(s"Cleanup {$operationName} failed.", e)
+        log.error(s"Cleanup $operationName failed.", e)
     }
 
     result

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.persistence.r2dbc.cleanup.scaladsl
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ClassicActorSystemProvider
+import pekko.actor.typed.ActorSystem
+import pekko.actor.typed.scaladsl.LoggerOps
+import pekko.actor.typed.scaladsl.adapter._
+import pekko.annotation.ApiMayChange
+import pekko.annotation.InternalApi
+import pekko.persistence.SnapshotSelectionCriteria
+import pekko.persistence.r2dbc.CleanupSettings
+import pekko.persistence.r2dbc.ConnectionFactoryProvider
+import pekko.persistence.r2dbc.JournalSettings
+import pekko.persistence.r2dbc.SnapshotSettings
+import pekko.persistence.r2dbc.journal.JournalDao
+import pekko.persistence.r2dbc.snapshot.SnapshotDao
+import org.slf4j.LoggerFactory
+
+/**
+ * Scala API: Tool for deleting all events and/or snapshots for a given list of `persistenceIds` without using
+ * persistent actors. It's important that the actors with corresponding `persistenceId` are not running at the same time
+ * as using the tool.
+ *
+ * If `resetSequenceNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ *
+ * When a list of `persistenceIds` are given they are deleted sequentially in the order of the list. It's possible to
+ * parallelize the deletes by running several cleanup operations at the same time operating on different sets of
+ * `persistenceIds`.
+ */
+@ApiMayChange
+final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, configPath: String) {
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "pekko.persistence.r2dbc.cleanup")
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[pekko] implicit val system: ActorSystem[_] =
+    systemProvider.classicSystem.toTyped
+
+  import system.executionContext
+
+  private val log = LoggerFactory.getLogger(classOf[EventSourcedCleanup])
+
+  private val sharedConfigPath = configPath.replaceAll("""\.cleanup$""", "")
+  private val settings = system.settings.config
+
+  private val cleanupSettings =
+    new CleanupSettings(settings.getConfig(sharedConfigPath + ".cleanup"))
+  private val journalSettings =
+    JournalSettings(settings.getConfig(sharedConfigPath + ".journal"))
+  private val snapshotSettings =
+    SnapshotSettings(settings.getConfig(sharedConfigPath + ".snapshot"))
+
+  private val connectionFactory =
+    ConnectionFactoryProvider(system).connectionFactoryFor(sharedConfigPath + ".connection-factory")
+  private val journalDao = new JournalDao(journalSettings, connectionFactory)
+  private val snapshotDao = new SnapshotDao(snapshotSettings, connectionFactory)
+
+  /**
+   * Delete all events before a sequenceNr for the given persistence id. Snapshots are not deleted.
+   *
+   * @param persistenceId
+   *   the persistence id to delete for
+   * @param toSequenceNr
+   *   sequence nr (inclusive) to delete up to
+   */
+  def deleteEventsTo(persistenceId: String, toSequenceNr: Long): Future[Done] = {
+    log.debug("deleteEventsTo persistenceId [{}], toSequenceNr [{}]", persistenceId, toSequenceNr)
+    journalDao
+      .deleteEventsTo(persistenceId, toSequenceNr, resetSequenceNumber = false,
+        cleanupSettings.eventsJournalDeleteBatchSize)
+      .map(_ => Done)
+  }
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    journalDao
+      .deleteEventsTo(persistenceId, toSequenceNr = Long.MaxValue, resetSequenceNumber,
+        cleanupSettings.eventsJournalDeleteBatchSize)
+      .map(_ => Done)
+  }
+
+  /**
+   * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteAllEvents", pid => deleteAllEvents(pid, resetSequenceNumber))
+  }
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): Future[Done] = {
+    snapshotDao
+      .delete(persistenceId, SnapshotSelectionCriteria(maxSequenceNr = Long.MaxValue))
+      .map(_ => Done)
+  }
+
+  /**
+   * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
+   */
+  def deleteSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
+    foreach(persistenceIds, "deleteSnapshots", pid => deleteSnapshot(pid))
+  }
+
+  /**
+   * Deletes all events for the given persistence id from before the snapshot. The snapshot is not deleted. The event
+   * with the same sequence number as the remaining snapshot is deleted.
+   */
+  def cleanupBeforeSnapshot(persistenceId: String): Future[Done] = {
+    snapshotDao.load(persistenceId, SnapshotSelectionCriteria.Latest).flatMap {
+      case None           => Future.successful(Done)
+      case Some(snapshot) => deleteEventsTo(persistenceId, snapshot.seqNr)
+    }
+  }
+
+  /**
+   * See single persistenceId overload for what is done for each persistence id
+   */
+  def cleanupBeforeSnapshot(persistenceIds: immutable.Seq[String]): Future[Done] = {
+    foreach(persistenceIds, "cleanupBeforeSnapshot", pid => cleanupBeforeSnapshot(pid))
+  }
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    for {
+      _ <- deleteAllEvents(persistenceId, resetSequenceNumber)
+      _ <- deleteSnapshot(persistenceId)
+    } yield Done
+  }
+
+  /**
+   * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteAll", pid => deleteAll(pid, resetSequenceNumber))
+  }
+
+  private def foreach(
+      persistenceIds: immutable.Seq[String],
+      operationName: String,
+      pidOperation: String => Future[Done]): Future[Done] = {
+    val size = persistenceIds.size
+    log.info("Cleanup started {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
+
+    def loop(remaining: List[String], n: Int): Future[Done] = {
+      remaining match {
+        case Nil => Future.successful(Done)
+        case pid :: tail =>
+          pidOperation(pid).flatMap { _ =>
+            if (n % cleanupSettings.logProgressEvery == 0)
+              log.infoN("Cleanup {} [{}] of [{}].", operationName, n: java.lang.Integer, size: java.lang.Integer)
+            loop(tail, n + 1)
+          }
+      }
+    }
+
+    val result = loop(persistenceIds.toList, n = 1)
+
+    result.onComplete {
+      case Success(_) =>
+        log.info2("Cleanup completed {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
+      case Failure(e) =>
+        log.error(s"Cleanup {$operationName} failed.", e)
+    }
+
+    result
+  }
+
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -190,7 +190,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
       case Success(_) =>
         log.info2("Cleanup completed {} of [{}] persistenceId.", operationName, size: java.lang.Integer)
       case Failure(e) =>
-        log.error(s"Cleanup {$operationName} failed.", e)
+        log.error(s"Cleanup $operationName failed.", e)
     }
 
     result

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -174,7 +174,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
 
     def loop(remaining: List[String], n: Int): Future[Done] = {
       remaining match {
-        case Nil => Future.successful(Done)
+        case Nil         => Future.successful(Done)
         case pid :: tail =>
           pidOperation(pid).flatMap { _ =>
             if (n % cleanupSettings.logProgressEvery == 0)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/JournalDao.scala
@@ -32,6 +32,7 @@ import pekko.persistence.r2dbc.internal.Sql.DialectInterpolation
 import pekko.persistence.r2dbc.journal.mysql.MySQLJournalDao
 import pekko.persistence.typed.PersistenceId
 import com.typesafe.config.Config
+import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
@@ -145,6 +146,12 @@ private[r2dbc] class JournalDao(val settings: JournalSettings, connectionFactory
   private val deleteEventsSql = sql"""
     DELETE FROM $journalTable
     WHERE persistence_id = ? AND seq_nr <= ?"""
+  private val deleteEventsRangeSql = sql"""
+    DELETE FROM $journalTable
+    WHERE persistence_id = ? AND seq_nr >= ? AND seq_nr <= ?"""
+  private val selectLowestSequenceNrSql = sql"""
+    SELECT MIN(seq_nr) from $journalTable
+    WHERE persistence_id = ?"""
   private val insertDeleteMarkerSql = sql"""
     INSERT INTO $journalTable
     (slice, entity_type, persistence_id, seq_nr, db_timestamp, writer, adapter_manifest, event_ser_id, event_ser_manifest, event_payload, deleted)
@@ -300,6 +307,97 @@ private[r2dbc] class JournalDao(val settings: JournalSettings, connectionFactory
 
       result.map(_ => ())(ExecutionContext.parasitic)
     }
+  }
+
+  def readLowestSequenceNr(persistenceId: String): Future[Long] = {
+    val result = r2dbcExecutor
+      .select(s"select lowest seqNr [$persistenceId]")(
+        connection =>
+          connection
+            .createStatement(selectLowestSequenceNrSql)
+            .bind(0, persistenceId),
+        row => {
+          val seqNr = row.get(0, classOf[java.lang.Long])
+          if (seqNr eq null) 0L else seqNr.longValue
+        })
+      .map(r => if (r.isEmpty) 0L else r.head)(ExecutionContext.parasitic)
+
+    if (log.isDebugEnabled)
+      result.foreach(seqNr => log.debug("Lowest sequence nr for persistenceId [{}]: [{}]", persistenceId, seqNr))
+
+    result
+  }
+
+  def deleteEventsTo(
+      persistenceId: String,
+      toSequenceNr: Long,
+      resetSequenceNumber: Boolean,
+      batchSize: Int): Future[Unit] = {
+
+    def insertDeleteMarkerStmt(deleteMarkerSeqNr: Long, connection: Connection): Statement = {
+      val entityType = PersistenceId.extractEntityType(persistenceId)
+      val slice = persistenceExt.sliceForPersistenceId(persistenceId)
+      connection
+        .createStatement(insertDeleteMarkerSql)
+        .bind(0, slice)
+        .bind(1, entityType)
+        .bind(2, persistenceId)
+        .bind(3, deleteMarkerSeqNr)
+        .bind(4, "")
+        .bind(5, "")
+        .bind(6, 0)
+        .bind(7, "")
+        .bind(8, Array.emptyByteArray)
+        .bind(9, true)
+    }
+
+    def deleteBatch(from: Long, to: Long, lastBatch: Boolean): Future[Unit] = {
+      (if (lastBatch && !resetSequenceNumber) {
+         r2dbcExecutor
+           .update(s"delete [$persistenceId] and insert marker") { connection =>
+             Vector(
+               connection.createStatement(deleteEventsRangeSql).bind(0, persistenceId).bind(1, from).bind(2, to),
+               insertDeleteMarkerStmt(to, connection))
+           }
+           .map(_.head)
+       } else {
+         r2dbcExecutor
+           .updateOne(s"delete [$persistenceId]") { connection =>
+             connection.createStatement(deleteEventsRangeSql).bind(0, persistenceId).bind(1, from).bind(2, to)
+           }
+       }).map { deletedRows =>
+        if (log.isDebugEnabled)
+          log.debug(
+            "Deleted [{}] events for persistenceId [{}], from seq num [{}] to [{}]",
+            deletedRows: java.lang.Long,
+            persistenceId,
+            from: java.lang.Long,
+            to: java.lang.Long)
+      }(ExecutionContext.parasitic)
+    }
+
+    def highestSeqNrForDelete(toSequenceNr: Long): Future[Long] =
+      if (toSequenceNr == Long.MaxValue) readHighestSequenceNr(persistenceId, 0L)
+      else Future.successful(toSequenceNr)
+
+    def lowestSequenceNrForDelete(toSeqNr: Long): Future[Long] =
+      if (toSeqNr <= batchSize) Future.successful(1L)
+      else readLowestSequenceNr(persistenceId)
+
+    def deleteInBatches(from: Long, maxTo: Long): Future[Unit] = {
+      if (from + batchSize > maxTo) {
+        deleteBatch(from, maxTo, lastBatch = true)
+      } else {
+        val to = from + batchSize - 1
+        deleteBatch(from, to, lastBatch = false).flatMap(_ => deleteInBatches(to + 1, maxTo))
+      }
+    }
+
+    for {
+      toSeqNr <- highestSeqNrForDelete(toSequenceNr)
+      fromSeqNr <- lowestSequenceNrForDelete(toSeqNr)
+      _ <- deleteInBatches(fromSeqNr, toSeqNr)
+    } yield ()
   }
 
 }


### PR DESCRIPTION
Ports the `EventSourcedCleanup` and `DurableStateCleanup` tools from [akka-persistence-r2dbc#326](https://github.com/akka/akka-persistence-r2dbc/pull/326) and [akka-persistence-r2dbc#329](https://github.com/akka/akka-persistence-r2dbc/pull/329), adapted for the pekko codebase.

These changes are now available under the Apache License, version 2.0.

## Changes

### New classes
- `cleanup/scaladsl/EventSourcedCleanup` — Scala API for deleting events and/or snapshots for a list of `persistenceIds`
- `cleanup/scaladsl/DurableStateCleanup` — Scala API for deleting durable state for a list of `persistenceIds`
- `cleanup/javadsl/EventSourcedCleanup` — Java API wrapper
- `cleanup/javadsl/DurableStateCleanup` — Java API wrapper

### Modified files
- **`R2dbcSettings.scala`** — added `CleanupSettings` class (`logProgressEvery`, `eventsJournalDeleteBatchSize`)
- **`reference.conf`** — added `pekko.persistence.r2dbc.cleanup` config block
- **`JournalDao.scala`** — added `readLowestSequenceNr`, `deleteEventsRangeSql` (range-based DELETE), and `deleteEventsTo` with batch deletion support (from PR #329)

## Adaptations from the original akka code
- Packages and annotations changed from `akka` → `pekko`
- Uses separate settings classes (`JournalSettings`, `SnapshotSettings`, `StateSettings`) instead of akka's unified `R2dbcSettings`
- Uses `deleteStateForRevision` (pekko's equivalent of akka's `deleteState`)
- Uses `scala.jdk.FutureConverters` / `scala.jdk.CollectionConverters` instead of `scala-java8-compat`
- `deleteEventsTo` takes `batchSize` as an explicit parameter since `JournalSettings` doesn't include cleanup settings
- Default config path uses `pekko.persistence.r2dbc.cleanup`