### PR TITLE
Enable additional capabilities in R2dbcDurableStateStoreTCKSpec

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/R2dbcDurableStateStoreTCKSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/R2dbcDurableStateStoreTCKSpec.scala
@@ -32,4 +32,10 @@ class R2dbcDurableStateStoreTCKSpec
   override def typedSystem: ActorSystem[_] = system.toTyped
 
   override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.on()
+
+  override protected def supportsUpsertWithRevisionCheck: CapabilityFlag = CapabilityFlag.on()
+
+  override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.on()
+
+  override protected def supportsSoftDelete: CapabilityFlag = CapabilityFlag.on()
 }


### PR DESCRIPTION
turns on more tests from the TCK