### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -27,7 +27,7 @@ object CommonSettings extends AutoPlugin {
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "--release", "17"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
       else Seq.empty
     },
     Test / logBuffered := false,

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -26,6 +26,10 @@ object CommonSettings extends AutoPlugin {
     crossVersion := CrossVersion.binary,
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "--release", "17"),
+    scalacOptions ++= {
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      else Seq.empty
+    },
     Test / logBuffered := false,
     Test / parallelExecution := false,
     // show full stack traces and test case durations


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059