### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -75,3 +75,13 @@ project.excludeFilters = [
   "scripts/authors.scala"
 ]
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -43,10 +43,10 @@ import io.r2dbc.spi.ConnectionFactoryOptions
 import io.r2dbc.spi.Option
 
 object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] {
-  def createExtension(system: ActorSystem[_]): ConnectionFactoryProvider = new ConnectionFactoryProvider(system)
+  def createExtension(system: ActorSystem[?]): ConnectionFactoryProvider = new ConnectionFactoryProvider(system)
 
   // Java API
-  def get(system: ActorSystem[_]): ConnectionFactoryProvider = apply(system)
+  def get(system: ActorSystem[?]): ConnectionFactoryProvider = apply(system)
 
   /**
    * Enables customization of [[ConnectionFactoryOptions]] right before the connection factory is created.
@@ -76,7 +76,7 @@ object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] 
   }
 }
 
-class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
+class ConnectionFactoryProvider(system: ActorSystem[?]) extends Extension {
 
   private val sessions = new ConcurrentHashMap[String, ConnectionPool]
 
@@ -111,7 +111,7 @@ class ConnectionFactoryProvider(system: ActorSystem[_]) extends Extension {
     settings.connectionFactoryOptionsCustomizer match {
       case None       => NoopCustomizer
       case Some(fqcn) =>
-        val args = List(classOf[ActorSystem[_]] -> system)
+        val args = List(classOf[ActorSystem[?]] -> system)
         system.dynamicAccess.createInstanceFor[ConnectionFactoryOptionsCustomizer](fqcn, args) match {
           case Success(customizer) => customizer
           case Failure(cause)      =>

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -143,7 +143,7 @@ final class StateSettings(val config: Config) extends ConnectionSettings with Us
   @InternalApi private[pekko] val durableStateAdditionalColumnClasses: Map[String, immutable.IndexedSeq[String]] = {
     val cfg = config.getConfig("additional-columns")
     cfg.root.unwrapped.asScala.toMap.map {
-      case (k, v: java.util.List[_]) => k -> v.iterator.asScala.map(_.toString).toVector
+      case (k, v: java.util.List[?]) => k -> v.iterator.asScala.map(_.toString).toVector
       case (k, v)                    => k -> Vector(v.toString)
     }
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -57,7 +57,7 @@ final class DurableStateCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * INTERNAL API
    */
-  @InternalApi private[pekko] implicit val system: ActorSystem[_] = {
+  @InternalApi private[pekko] implicit val system: ActorSystem[?] = {
     import pekko.actor.typed.scaladsl.adapter._
     systemProvider.classicSystem.toTyped
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -63,7 +63,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * INTERNAL API
    */
-  @InternalApi private[pekko] implicit val system: ActorSystem[_] = {
+  @InternalApi private[pekko] implicit val system: ActorSystem[?] = {
     import pekko.actor.typed.scaladsl.adapter._
     systemProvider.classicSystem.toTyped
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/AdditionalColumnFactory.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/AdditionalColumnFactory.scala
@@ -34,7 +34,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
   final class AdditionalColumnAdapter(delegate: javadslState.AdditionalColumn[Any, Any])
       extends AdditionalColumn[Any, Any] {
 
-    override private[pekko] val fieldClass: Class[_] =
+    override private[pekko] val fieldClass: Class[?] =
       delegate.fieldClass
 
     override def columnName: String =
@@ -48,7 +48,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
         upsert.revision,
         upsert.value)
       delegate.bind(javadslUpsert) match {
-        case bindValue: javadslState.AdditionalColumn.BindValue[_] => AdditionalColumn.BindValue(bindValue.value)
+        case bindValue: javadslState.AdditionalColumn.BindValue[?] => AdditionalColumn.BindValue(bindValue.value)
         case javadslState.AdditionalColumn.BindNull                => AdditionalColumn.BindNull
         case javadslState.AdditionalColumn.Skip                    => AdditionalColumn.Skip
       }
@@ -56,7 +56,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
 
   }
 
-  def create(system: ActorSystem[_], fqcn: String): AdditionalColumn[Any, Any] = {
+  def create(system: ActorSystem[?], fqcn: String): AdditionalColumn[Any, Any] = {
     val dynamicAccess = system.classicSystem.asInstanceOf[ExtendedActorSystem].dynamicAccess
 
     def tryCreateScaladslInstance(): Try[AdditionalColumn[Any, Any]] = {
@@ -64,7 +64,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
         .createInstanceFor[AdditionalColumn[Any, Any]](fqcn, Nil)
         .orElse(
           dynamicAccess
-            .createInstanceFor[AdditionalColumn[Any, Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .createInstanceFor[AdditionalColumn[Any, Any]](fqcn, List(classOf[ActorSystem[?]] -> system))
             .orElse(dynamicAccess.createInstanceFor[AdditionalColumn[Any, Any]](
               fqcn,
               List(classOf[ClassicActorSystem] -> system.classicSystem))))
@@ -77,7 +77,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
           dynamicAccess
             .createInstanceFor[javadslState.AdditionalColumn[Any, Any]](
               fqcn,
-              List(classOf[ActorSystem[_]] -> system))
+              List(classOf[ActorSystem[?]] -> system))
             .orElse(dynamicAccess.createInstanceFor[javadslState.AdditionalColumn[Any, Any]](
               fqcn,
               List(classOf[ClassicActorSystem] -> system.classicSystem))))
@@ -91,7 +91,7 @@ import pekko.persistence.r2dbc.state.{ javadsl => javadslState }
       .getOrElse(
         throw new IllegalArgumentException(
           s"Additional column [$fqcn] must implement " +
-          s"[${classOf[AdditionalColumn[_, _]].getName}] or [${classOf[javadslState.AdditionalColumn[_, _]].getName}]. It " +
+          s"[${classOf[AdditionalColumn[?, ?]].getName}] or [${classOf[javadslState.AdditionalColumn[?, ?]].getName}]. It " +
           s"may have an ActorSystem constructor parameter."))
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/ChangeHandlerFactory.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/ChangeHandlerFactory.scala
@@ -43,7 +43,7 @@ import pekko.persistence.r2dbc.state.scaladsl.ChangeHandler
     }
   }
 
-  def create(system: ActorSystem[_], fqcn: String): ChangeHandler[Any] = {
+  def create(system: ActorSystem[?], fqcn: String): ChangeHandler[Any] = {
     val dynamicAccess = system.classicSystem.asInstanceOf[ExtendedActorSystem].dynamicAccess
 
     def tryCreateScaladslInstance(): Try[ChangeHandler[Any]] = {
@@ -51,7 +51,7 @@ import pekko.persistence.r2dbc.state.scaladsl.ChangeHandler
         .createInstanceFor[ChangeHandler[Any]](fqcn, Nil)
         .orElse(
           dynamicAccess
-            .createInstanceFor[ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .createInstanceFor[ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[?]] -> system))
             .orElse(
               dynamicAccess
                 .createInstanceFor[ChangeHandler[Any]](
@@ -64,7 +64,7 @@ import pekko.persistence.r2dbc.state.scaladsl.ChangeHandler
         .createInstanceFor[javadslState.ChangeHandler[Any]](fqcn, Nil)
         .orElse(
           dynamicAccess
-            .createInstanceFor[javadslState.ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[_]] -> system))
+            .createInstanceFor[javadslState.ChangeHandler[Any]](fqcn, List(classOf[ActorSystem[?]] -> system))
             .orElse(
               dynamicAccess
                 .createInstanceFor[javadslState.ChangeHandler[Any]](
@@ -80,7 +80,7 @@ import pekko.persistence.r2dbc.state.scaladsl.ChangeHandler
       .getOrElse(
         throw new IllegalArgumentException(
           s"Change handler [$fqcn] must implement " +
-          s"[${classOf[ChangeHandler[_]].getName}] or [${classOf[javadslState.ChangeHandler[_]].getName}]. It " +
+          s"[${classOf[ChangeHandler[?]].getName}] or [${classOf[javadslState.ChangeHandler[?]].getName}]. It " +
           s"may have an ActorSystem constructor parameter."))
 
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/EnvelopeOrigin.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/EnvelopeOrigin.scala
@@ -25,18 +25,18 @@ import pekko.persistence.query.typed.EventEnvelope
   val SourceBacktracking = "BT"
   val SourcePubSub = "PS"
 
-  def fromQuery(env: EventEnvelope[_]): Boolean =
+  def fromQuery(env: EventEnvelope[?]): Boolean =
     env.source == SourceQuery
 
-  def fromBacktracking(env: EventEnvelope[_]): Boolean =
+  def fromBacktracking(env: EventEnvelope[?]): Boolean =
     env.source == SourceBacktracking
 
-  def fromPubSub(env: EventEnvelope[_]): Boolean =
+  def fromPubSub(env: EventEnvelope[?]): Boolean =
     env.source == SourcePubSub
 
   def isFilteredEvent(env: Any): Boolean =
     env match {
-      case e: EventEnvelope[_] => e.filtered
+      case e: EventEnvelope[?] => e.filtered
       case _                   => false
     }
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/PayloadCodec.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/PayloadCodec.scala
@@ -24,7 +24,7 @@ import io.r2dbc.spi.Statement
  * INTERNAL API
  */
 @InternalApi private[pekko] sealed trait PayloadCodec {
-  def payloadClass: Class[_]
+  def payloadClass: Class[?]
   def encode(bytes: Array[Byte]): Any
   def decode(payload: Any): Array[Byte]
   def nonePayload: Array[Byte]

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/PubSub.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/PubSub.scala
@@ -41,17 +41,17 @@ import org.slf4j.LoggerFactory
 @InternalApi private[pekko] object PubSub extends ExtensionId[PubSub] {
   private val log = LoggerFactory.getLogger(classOf[PubSub])
 
-  def createExtension(system: ActorSystem[_]): PubSub = new PubSub(system)
+  def createExtension(system: ActorSystem[?]): PubSub = new PubSub(system)
 
   // Java API
-  def get(system: ActorSystem[_]): PubSub = apply(system)
+  def get(system: ActorSystem[?]): PubSub = apply(system)
 
 }
 
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] class PubSub(system: ActorSystem[_]) extends Extension {
+@InternalApi private[pekko] class PubSub(system: ActorSystem[?]) extends Extension {
   import PubSub.log
 
   private val topics = new ConcurrentHashMap[String, ActorRef[Any]]

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -83,14 +83,14 @@ import reactor.core.publisher.Mono
   def selectOneInTx[A](statement: Statement, mapRow: Row => A)(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[_]): Future[Option[A]] = {
+      system: ActorSystem[?]): Future[Option[A]] = {
     selectInTx(statement, mapRow).map(_.headOption)
   }
 
   def selectInTx[A](statement: Statement, mapRow: Row => A)(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[_]): Future[immutable.IndexedSeq[A]] = {
+      system: ActorSystem[?]): Future[immutable.IndexedSeq[A]] = {
     statement.execute().asFuture().flatMap { result =>
       val consumer: BiConsumer[mutable.Builder[A, immutable.IndexedSeq[A]], A] = (builder, elem) => builder += elem
       Flux
@@ -111,7 +111,7 @@ import reactor.core.publisher.Mono
 class R2dbcExecutor(val connectionFactory: ConnectionFactory, log: Logger, logDbCallsExceeding: FiniteDuration)(
     implicit
     ec: ExecutionContext,
-    system: ActorSystem[_]) {
+    system: ActorSystem[?]) {
   import R2dbcExecutor._
 
   private val logDbCallsExceedingMicros = logDbCallsExceeding.toMicros

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/JournalDao.scala
@@ -81,7 +81,7 @@ private[r2dbc] object JournalDao {
   def fromConfig(
       settings: JournalSettings,
       config: Config
-  )(implicit system: ActorSystem[_], ec: ExecutionContext): JournalDao = {
+  )(implicit system: ActorSystem[?], ec: ExecutionContext): JournalDao = {
     val connectionFactory =
       ConnectionFactoryProvider(system).connectionFactoryFor(settings.useConnectionFactory, config)
     settings.dialect match {
@@ -100,7 +100,7 @@ private[r2dbc] object JournalDao {
  */
 @InternalApi
 private[r2dbc] class JournalDao(val settings: JournalSettings, connectionFactory: ConnectionFactory)(
-    implicit val ec: ExecutionContext, system: ActorSystem[_]) extends EventsByPersistenceIdDao
+    implicit val ec: ExecutionContext, system: ActorSystem[?]) extends EventsByPersistenceIdDao
     with HighestSequenceNrDao {
   import JournalDao.SerializedJournalRow
   import JournalDao.log

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -48,7 +48,7 @@ import pekko.stream.scaladsl.Sink
  */
 @InternalApi
 private[r2dbc] object R2dbcJournal {
-  case class WriteFinished(persistenceId: String, done: Future[_])
+  case class WriteFinished(persistenceId: String, done: Future[?])
 
   def deserializeRow(serialization: Serialization, row: SerializedJournalRow): PersistentRepr = {
     if (row.payload.isEmpty)
@@ -80,7 +80,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
   import R2dbcJournal.WriteFinished
   import R2dbcJournal.deserializeRow
 
-  implicit val system: ActorSystem[_] = context.system.toTyped
+  implicit val system: ActorSystem[?] = context.system.toTyped
   implicit val ec: ExecutionContext = context.dispatcher
 
   private val log = Logging(context.system, classOf[R2dbcJournal])
@@ -98,7 +98,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
 
   // if there are pending writes when an actor restarts we must wait for
   // them to complete before we can read the highest sequence number or we will miss it
-  private val writesInProgress = new java.util.HashMap[String, Future[_]]()
+  private val writesInProgress = new java.util.HashMap[String, Future[?]]()
 
   override def receivePluginInternal: Receive = { case WriteFinished(pid, f) =>
     writesInProgress.remove(pid, f)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/mysql/MySQLJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/mysql/MySQLJournalDao.scala
@@ -119,7 +119,7 @@ private[r2dbc] object MySQLJournalDao {
 private[r2dbc] class MySQLJournalDao(
     journalSettings: JournalSettings,
     connectionFactory: ConnectionFactory)(
-    implicit ec: ExecutionContext, system: ActorSystem[_]
+    implicit ec: ExecutionContext, system: ActorSystem[?]
 ) extends JournalDao(journalSettings, connectionFactory) {
   MySQLJournalDao.settingRequirements(journalSettings)
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -58,7 +58,7 @@ object QueryDao {
   def fromConfig(
       settings: QuerySettings,
       config: Config
-  )(implicit system: ActorSystem[_], ec: ExecutionContext): QueryDao = {
+  )(implicit system: ActorSystem[?], ec: ExecutionContext): QueryDao = {
     val connectionFactory =
       ConnectionFactoryProvider(system).connectionFactoryFor(settings.useConnectionFactory, config)
     settings.dialect match {
@@ -75,7 +75,7 @@ object QueryDao {
  */
 @InternalApi
 private[r2dbc] class QueryDao(val settings: QuerySettings, connectionFactory: ConnectionFactory)(
-    implicit val ec: ExecutionContext, system: ActorSystem[_]) extends BySliceQuery.Dao[SerializedJournalRow]
+    implicit val ec: ExecutionContext, system: ActorSystem[?]) extends BySliceQuery.Dao[SerializedJournalRow]
     with EventsByPersistenceIdDao with HighestSequenceNrDao {
   import JournalDao.readMetadata
   import QueryDao.log

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -81,7 +81,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
   private val log = LoggerFactory.getLogger(getClass)
   private val settings = QuerySettings(config)
 
-  private implicit val typedSystem: ActorSystem[_] = system.toTyped
+  private implicit val typedSystem: ActorSystem[?] = system.toTyped
   import typedSystem.executionContext
   private val serialization = SerializationExtension(system)
   private val persistenceExt = Persistence(system)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/mysql/MySQLQueryDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/mysql/MySQLQueryDao.scala
@@ -42,7 +42,7 @@ import io.r2dbc.spi.Row
 private[r2dbc] class MySQLQueryDao(
     querySettings: QuerySettings,
     connectionFactory: ConnectionFactory
-)(implicit ec: ExecutionContext, system: ActorSystem[_]) extends QueryDao(querySettings, connectionFactory) {
+)(implicit ec: ExecutionContext, system: ActorSystem[?]) extends QueryDao(querySettings, connectionFactory) {
 
   override lazy val statementTimestampSql: String = "NOW(6)"
 

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/javadsl/R2dbcSession.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/javadsl/R2dbcSession.scala
@@ -38,12 +38,12 @@ object R2dbcSession {
    * Runs the passed function using a R2dbcSession with a new transaction. The connection is closed and the transaction
    * is committed at the end or rolled back in case of failures.
    */
-  def withSession[A](system: ActorSystem[_], fun: JFunction[R2dbcSession, CompletionStage[A]]): CompletionStage[A] = {
+  def withSession[A](system: ActorSystem[?], fun: JFunction[R2dbcSession, CompletionStage[A]]): CompletionStage[A] = {
     withSession(system, "pekko.persistence.r2dbc.connection-factory", fun)
   }
 
   def withSession[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       connectionFactoryConfigPath: String,
       fun: JFunction[R2dbcSession, CompletionStage[A]]): CompletionStage[A] = {
     scaladslSession.R2dbcSession.withSession(system, connectionFactoryConfigPath) { scaladslSession =>
@@ -55,7 +55,7 @@ object R2dbcSession {
 }
 
 @ApiMayChange
-final class R2dbcSession(val connection: Connection)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
+final class R2dbcSession(val connection: Connection)(implicit ec: ExecutionContext, system: ActorSystem[?]) {
 
   def createStatement(sql: String): Statement =
     connection.createStatement(sql)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
@@ -38,11 +38,11 @@ object R2dbcSession {
    * Runs the passed function using a R2dbcSession with a new transaction. The connection is closed and the transaction
    * is committed at the end or rolled back in case of failures.
    */
-  def withSession[A](system: ActorSystem[_])(fun: R2dbcSession => Future[A]): Future[A] = {
+  def withSession[A](system: ActorSystem[?])(fun: R2dbcSession => Future[A]): Future[A] = {
     withSession(system, "pekko.persistence.r2dbc.connection-factory")(fun)
   }
 
-  def withSession[A](system: ActorSystem[_], connectionFactoryConfigPath: String)(
+  def withSession[A](system: ActorSystem[?], connectionFactoryConfigPath: String)(
       fun: R2dbcSession => Future[A]): Future[A] = {
     val connectionFactory = ConnectionFactoryProvider(system).connectionFactoryFor(connectionFactoryConfigPath)
     val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsDisabled)(system.executionContext, system)
@@ -54,7 +54,7 @@ object R2dbcSession {
 }
 
 @ApiMayChange
-final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionContext, val system: ActorSystem[_]) {
+final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionContext, val system: ActorSystem[?]) {
 
   def createStatement(sql: String): Statement =
     connection.createStatement(sql)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/R2dbcSnapshotStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/R2dbcSnapshotStore.scala
@@ -57,7 +57,7 @@ private[r2dbc] final class R2dbcSnapshotStore(cfg: Config, cfgPath: String) exte
 
   private implicit val ec: ExecutionContext = context.dispatcher
   private val serialization: Serialization = SerializationExtension(context.system)
-  private implicit val system: ActorSystem[_] = context.system.toTyped
+  private implicit val system: ActorSystem[?] = context.system.toTyped
 
   private val dao = {
     val settings = SnapshotSettings(cfg)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/SnapshotDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/SnapshotDao.scala
@@ -56,7 +56,7 @@ private[r2dbc] object SnapshotDao {
   def fromConfig(
       settings: SnapshotSettings,
       config: Config
-  )(implicit system: ActorSystem[_], ec: ExecutionContext): SnapshotDao = {
+  )(implicit system: ActorSystem[?], ec: ExecutionContext): SnapshotDao = {
     val connectionFactory =
       ConnectionFactoryProvider(system).connectionFactoryFor(settings.useConnectionFactory, config)
     settings.dialect match {
@@ -77,7 +77,7 @@ private[r2dbc] object SnapshotDao {
 private[r2dbc] class SnapshotDao(settings: SnapshotSettings, connectionFactory: ConnectionFactory)(
     implicit
     ec: ExecutionContext,
-    system: ActorSystem[_]) {
+    system: ActorSystem[?]) {
   import SnapshotDao._
 
   implicit protected val dialect: Dialect = settings.dialect

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/mysql/MySQLSnapshotDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/snapshot/mysql/MySQLSnapshotDao.scala
@@ -34,7 +34,7 @@ import pekko.persistence.r2dbc.snapshot.SnapshotDao
 @InternalApi
 private[r2dbc] class MySQLSnapshotDao(
     settings: SnapshotSettings, connectionFactory: ConnectionFactory
-)(implicit ec: ExecutionContext, system: ActorSystem[_]) extends SnapshotDao(settings, connectionFactory) {
+)(implicit ec: ExecutionContext, system: ActorSystem[?]) extends SnapshotDao(settings, connectionFactory) {
 
   override val upsertSql = sql"""
     INSERT INTO $snapshotTable

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/AdditionalColumn.scala
@@ -31,7 +31,7 @@ object AdditionalColumn {
 
   case object Skip extends Binding[Nothing]
 
-  private val scalaPrimitivesMapping: Map[Class[_], Class[_]] =
+  private val scalaPrimitivesMapping: Map[Class[?], Class[?]] =
     Map(
       classOf[Int] -> classOf[java.lang.Integer],
       classOf[Long] -> classOf[java.lang.Long],
@@ -56,7 +56,7 @@ abstract class AdditionalColumn[A, B: ClassTag] {
   /**
    * INTERNAL API: used when binding null
    */
-  @InternalApi private[pekko] val fieldClass: Class[_] = {
+  @InternalApi private[pekko] val fieldClass: Class[?] = {
     val cls = implicitly[ClassTag[B]].runtimeClass
     scalaPrimitivesMapping.getOrElse(cls, cls)
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -83,15 +83,15 @@ import org.slf4j.LoggerFactory
   }
 
   private final case class EvaluatedAdditionalColumnBindings(
-      additionalColumn: AdditionalColumn[_, _],
-      binding: AdditionalColumn.Binding[_])
+      additionalColumn: AdditionalColumn[?, ?],
+      binding: AdditionalColumn.Binding[?])
 
   private val FutureDone: Future[Done] = Future.successful(Done)
 
   def fromConfig(
       settings: StateSettings,
       config: Config
-  )(implicit system: ActorSystem[_], ec: ExecutionContext): DurableStateDao = {
+  )(implicit system: ActorSystem[?], ec: ExecutionContext): DurableStateDao = {
     val connectionFactory =
       ConnectionFactoryProvider(system).connectionFactoryFor(settings.useConnectionFactory, config)
     settings.dialect match {
@@ -112,7 +112,7 @@ import org.slf4j.LoggerFactory
 private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory: ConnectionFactory)(
     implicit
     ec: ExecutionContext,
-    system: ActorSystem[_])
+    system: ActorSystem[?])
     extends BySliceQuery.Dao[DurableStateDao.SerializedStateRow] {
   import DurableStateDao._
 
@@ -187,7 +187,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
     else {
       val strB = new lang.StringBuilder()
       additionalBindings.foreach {
-        case EvaluatedAdditionalColumnBindings(c, _: AdditionalColumn.BindValue[_]) =>
+        case EvaluatedAdditionalColumnBindings(c, _: AdditionalColumn.BindValue[?]) =>
           strB.append(", ").append(c.columnName)
         case EvaluatedAdditionalColumnBindings(c, AdditionalColumn.BindNull) =>
           strB.append(", ").append(c.columnName)
@@ -203,7 +203,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
     else {
       val strB = new lang.StringBuilder()
       additionalBindings.foreach {
-        case EvaluatedAdditionalColumnBindings(_, _: AdditionalColumn.BindValue[_]) |
+        case EvaluatedAdditionalColumnBindings(_, _: AdditionalColumn.BindValue[?]) |
             EvaluatedAdditionalColumnBindings(_, AdditionalColumn.BindNull) =>
           strB.append(", ?")
         case EvaluatedAdditionalColumnBindings(_, AdditionalColumn.Skip) =>
@@ -245,7 +245,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
     else {
       val strB = new lang.StringBuilder()
       additionalBindings.foreach {
-        case EvaluatedAdditionalColumnBindings(col, _: AdditionalColumn.BindValue[_]) =>
+        case EvaluatedAdditionalColumnBindings(col, _: AdditionalColumn.BindValue[?]) =>
           strB.append(", ").append(col.columnName).append(" = ?")
         case EvaluatedAdditionalColumnBindings(col, AdditionalColumn.BindNull) =>
           strB.append(", ").append(col.columnName).append(" = ?")
@@ -474,8 +474,8 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
 
     def excMessage(cause: Throwable): String = {
       val (changeType, revision) = change match {
-        case upd: UpdatedDurableState[_] => "update" -> upd.revision
-        case del: DeletedDurableState[_] => "delete" -> del.revision
+        case upd: UpdatedDurableState[?] => "update" -> upd.revision
+        case del: DeletedDurableState[?] => "delete" -> del.revision
       }
       s"Change handler $changeType failed for [${change.persistenceId}] revision [$revision], due to ${cause.getMessage}"
     }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -61,7 +61,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
   private val log = LoggerFactory.getLogger(getClass)
   private val settings = StateSettings(config)
 
-  private implicit val typedSystem: ActorSystem[_] = system.toTyped
+  private implicit val typedSystem: ActorSystem[?] = system.toTyped
   implicit val ec: ExecutionContext = system.dispatcher
   private val serialization = SerializationExtension(system)
   private val persistenceExt = Persistence(system)

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/mysql/MySQLDurableStateDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/mysql/MySQLDurableStateDao.scala
@@ -42,7 +42,7 @@ import io.r2dbc.spi.Statement
 private[r2dbc] class MySQLDurableStateDao(
     settings: StateSettings,
     connectionFactory: ConnectionFactory
-)(implicit ec: ExecutionContext, system: ActorSystem[_]) extends DurableStateDao(settings, connectionFactory) {
+)(implicit ec: ExecutionContext, system: ActorSystem[?]) extends DurableStateDao(settings, connectionFactory) {
   MySQLJournalDao.settingRequirements(settings)
 
   override lazy val transactionTimestampSql: String = "NOW(6)"

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryOptionsCustomizerSpec.scala
@@ -41,7 +41,7 @@ class ConnectionFactoryOptionsCustomizerSpec extends ScalaTestWithActorTestKit(c
 object ConnectionFactoryOptionsCustomizerSpec {
   object CustomizerCalled
 
-  class Customizer(system: ActorSystem[_]) extends ConnectionFactoryOptionsCustomizer {
+  class Customizer(system: ActorSystem[?]) extends ConnectionFactoryOptionsCustomizer {
     override def apply(builder: ConnectionFactoryOptions.Builder, config: Config): ConnectionFactoryOptions.Builder = {
       system.eventStream.tell(EventStream.Publish(CustomizerCalled))
       builder

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/PayloadSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/PayloadSpec.scala
@@ -69,7 +69,7 @@ class PayloadSpec
     with LogCapturing {
   import PayloadSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private def testJournalPersister(persistenceId: String, msg: Any): Unit = {
     val probe = createTestProbe[Any]()

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/TestDbLifecycle.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/TestDbLifecycle.scala
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory
 
 trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
 
-  def typedSystem: ActorSystem[_]
+  def typedSystem: ActorSystem[?]
 
   def testConfigPath: String = "pekko.persistence.r2dbc"
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanupSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanupSpec.scala
@@ -43,7 +43,7 @@ class DurableStateCleanupSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   "DurableStateCleanup" must {
     "delete state for one persistenceId" in {

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
@@ -48,7 +48,7 @@ class EventSourcedCleanupSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   "EventSourcedCleanup" must {
     "delete events for one persistenceId" in {

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/MultiPluginSpec.scala
@@ -102,7 +102,7 @@ class MultiPluginSpec
 
   import MultiPluginSpec.MyEntity
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   "Addition plugin config" should {
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/PersistTagsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/PersistTagsSpec.scala
@@ -35,7 +35,7 @@ class PersistTagsSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private val settings = JournalSettings(system.settings.config.getConfig("pekko.persistence.r2dbc.journal"))
 
   case class Row(pid: String, seqNr: Long, tags: Set[String])

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/PersistTimestampSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/PersistTimestampSpec.scala
@@ -39,7 +39,7 @@ class PersistTimestampSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private val settings = JournalSettings(system.settings.config.getConfig("pekko.persistence.r2dbc.journal"))
   private val serialization = SerializationExtension(system)
   private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalPerfManyActorsSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalPerfManyActorsSpec.scala
@@ -36,7 +36,7 @@ class R2dbcJournalPerfManyActorsSpec extends JournalPerfSpec(R2dbcJournalPerfSpe
 
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
 
-  override def typedSystem: ActorSystem[_] = system.toTyped
+  override def typedSystem: ActorSystem[?] = system.toTyped
 
   def actorCount = 20 // increase when testing for real
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalPerfSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalPerfSpec.scala
@@ -35,5 +35,5 @@ class R2dbcJournalPerfSpec extends JournalPerfSpec(R2dbcJournalPerfSpec.config) 
 
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
 
-  override def typedSystem: ActorSystem[_] = system.toTyped
+  override def typedSystem: ActorSystem[?] = system.toTyped
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournalSpec.scala
@@ -44,11 +44,11 @@ object R2dbcJournalSpec {
 
 class R2dbcJournalSpec extends JournalSpec(R2dbcJournalSpec.config) with TestDbLifecycle {
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
-  override def typedSystem: ActorSystem[_] = system.toTyped
+  override def typedSystem: ActorSystem[?] = system.toTyped
 }
 
 class R2dbcJournalWithMetaSpec extends JournalSpec(R2dbcJournalSpec.configWithMeta) with TestDbLifecycle {
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
   protected override def supportsMetadata: CapabilityFlag = CapabilityFlag.on()
-  override def typedSystem: ActorSystem[_] = system.toTyped
+  override def typedSystem: ActorSystem[?] = system.toTyped
 }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/RuntimePluginConfigSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/RuntimePluginConfigSpec.scala
@@ -119,7 +119,7 @@ object RuntimePluginConfigSpec {
   }
 
   trait DurableState {
-    def typedSystem: ActorSystem[_]
+    def typedSystem: ActorSystem[?]
     def configKey: String
     def database: String
 
@@ -169,12 +169,12 @@ class RuntimePluginConfigSpec
   }
 
   private lazy val state1 = new DurableState {
-    override def typedSystem: ActorSystem[_] = system
+    override def typedSystem: ActorSystem[?] = system
     override def configKey: String = "plugin1"
     override def database: String = "database1"
   }
   private lazy val state2 = new DurableState {
-    override def typedSystem: ActorSystem[_] = system
+    override def typedSystem: ActorSystem[?] = system
     override def configKey: String = "plugin2"
     override def database: String = "database2"
   }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/TestDataGenerator.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/journal/TestDataGenerator.scala
@@ -71,7 +71,7 @@ object TestDataGenerator {
         Behaviors.same
       }
 
-    def startEventsByQuery(system: ActorSystem[_]): Unit = {
+    def startEventsByQuery(system: ActorSystem[?]): Unit = {
       import system.executionContext
       implicit val sys = system
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/CurrentPersistenceIdsQuerySpec.scala
@@ -44,7 +44,7 @@ class CurrentPersistenceIdsQuerySpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsByPersistenceIdGapSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsByPersistenceIdGapSpec.scala
@@ -69,7 +69,7 @@ class EventsByPersistenceIdGapSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query =
     PersistenceQuery(system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsByPersistenceIdSpec.scala
@@ -51,7 +51,7 @@ class EventsByPersistenceIdSpec
     with LogCapturing {
   import EventsByPersistenceIdSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 
@@ -64,7 +64,7 @@ class EventsByPersistenceIdSpec
           query.currentEventsByPersistenceId(pid, from, to)
       }
 
-    def assertFinished(probe: TestSubscriber.Probe[_], liveShouldFinish: Boolean = false): Unit =
+    def assertFinished(probe: TestSubscriber.Probe[?], liveShouldFinish: Boolean = false): Unit =
       queryType match {
         case Live if !liveShouldFinish =>
           probe.expectNoMessage()

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -58,7 +58,7 @@ class EventsBySliceBacktrackingSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private val settings = QuerySettings(system.settings.config.getConfig("pekko.persistence.r2dbc.query"))
   private implicit val journalPayloadCodec: PayloadCodec = settings.journalPayloadCodec
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePerfSpec.scala
@@ -62,7 +62,7 @@ class EventsBySlicePerfSpec
     with TestData {
   import EventsBySlicePerfSpec.PidSeqNr
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubOverflowSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubOverflowSpec.scala
@@ -66,7 +66,7 @@ class EventsBySlicePubSubOverflowSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query =
     PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
@@ -82,7 +82,7 @@ class EventsBySlicePubSubSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -83,7 +83,7 @@ class EventsBySliceSpec
     with LogCapturing {
   import EventsBySliceSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = PersistenceQuery(testKit.system).readJournalFor[R2dbcReadJournal](R2dbcReadJournal.Identifier)
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/snapshot/R2dbcSnapshotStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/snapshot/R2dbcSnapshotStoreSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.Outcome
 import org.scalatest.Pending
 
 class R2dbcSnapshotStoreSpec extends SnapshotStoreSpec(TestConfig.config) with TestDbLifecycle {
-  def typedSystem: ActorSystem[_] = system.toTyped
+  def typedSystem: ActorSystem[?] = system.toTyped
 
   val ignoreTests = Set(
     // All these expects multiple snapshots for same pid, either as the core test

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/CurrentPersistenceIdsQuerySpec.scala
@@ -52,7 +52,7 @@ class CurrentPersistenceIdsQuerySpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val store = DurableStateStoreRegistry(testKit.system)
     .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateBySliceSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateBySliceSpec.scala
@@ -71,7 +71,7 @@ class DurableStateBySliceSpec
     with LogCapturing {
   import DurableStateBySliceSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val query = DurableStateStoreRegistry(testKit.system)
     .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)
@@ -108,7 +108,7 @@ class DurableStateBySliceSpec
           queryImpl.currentChangesBySlices(entityType, minSlice, maxSlice, offset)
       }
 
-    def assertFinished(probe: TestProbe[_], streamDone: Future[Done]): Unit =
+    def assertFinished(probe: TestProbe[?], streamDone: Future[Done]): Unit =
       queryType match {
         case Live =>
           probe.expectNoMessage()

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreAdditionalColumnSpec.scala
@@ -83,7 +83,7 @@ class DurableStateStoreAdditionalColumnSpec
 
   private val customTable = stateSettings.getDurableStateTableWithSchema("CustomEntity")
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreChangeHandlerSpec.scala
@@ -58,7 +58,7 @@ object DurableStateStoreChangeHandlerSpec {
     if (dialect == "mysql") "insert into changes_test (pid, rev, value) values (?, ?, ?)"
     else sql"insert into changes_test (pid, rev, value) values (?, ?, ?)"
 
-  class Handler(system: ActorSystem[_]) extends ChangeHandler[String] {
+  class Handler(system: ActorSystem[?]) extends ChangeHandler[String] {
     private implicit val ec: ExecutionContext = system.executionContext
 
     override def process(session: R2dbcSession, change: DurableStateChange[String]): Future[Done] = {
@@ -100,7 +100,7 @@ class DurableStateStoreChangeHandlerSpec
 
   private val anotherTable = "changes_test"
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
@@ -33,7 +33,7 @@ class DurableStateStoreSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val store = DurableStateStoreRegistry(testKit.system)
     .durableStateStoreFor[R2dbcDurableStateStore[String]](R2dbcDurableStateStore.Identifier)

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/R2dbcDurableStateStoreTCKSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/R2dbcDurableStateStoreTCKSpec.scala
@@ -29,7 +29,7 @@ class R2dbcDurableStateStoreTCKSpec
     extends DurableStateStoreSpec(TestConfig.config)
     with TestDbLifecycle {
 
-  override def typedSystem: ActorSystem[_] = system.toTyped
+  override def typedSystem: ActorSystem[?] = system.toTyped
 
   override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.on()
 

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/TestDataGenerator.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/TestDataGenerator.scala
@@ -73,7 +73,7 @@ object TestDataGenerator {
         Behaviors.same
       }
 
-    def startChangesByQuery(system: ActorSystem[_]): Unit = {
+    def startChangesByQuery(system: ActorSystem[?]): Unit = {
       import system.executionContext
       implicit val sys = system
 

--- a/docs/src/test/scala/docs/home/RuntimePluginConfigExample.scala
+++ b/docs/src/test/scala/docs/home/RuntimePluginConfigExample.scala
@@ -31,7 +31,7 @@ object RuntimePluginConfigExample {
   type Command
   type Event
   type State
-  val context: ActorContext[_] = ???
+  val context: ActorContext[?] = ???
 
   // #runtime-plugin-config
   class EventSourcedBehaviorForDatabase(database: String) {

--- a/docs/src/test/scala/docs/home/cleanup/CleanupDocExample.scala
+++ b/docs/src/test/scala/docs/home/cleanup/CleanupDocExample.scala
@@ -26,7 +26,7 @@ import pekko.persistence.r2dbc.query.scaladsl.R2dbcReadJournal
 
 object CleanupDocExample {
 
-  implicit val system: ActorSystem[_] = ???
+  implicit val system: ActorSystem[?] = ???
 
   // #cleanup
   val queries = PersistenceQuery(system).readJournalFor[CurrentPersistenceIdsQuery](R2dbcReadJournal.Identifier)

--- a/docs/src/test/scala/docs/home/query/QueryDocCompileOnly.scala
+++ b/docs/src/test/scala/docs/home/query/QueryDocCompileOnly.scala
@@ -20,7 +20,7 @@ import pekko.persistence.typed.PersistenceId
 import pekko.stream.scaladsl.Sink
 
 object QueryDocCompileOnly {
-  implicit val system: ActorSystem[_] = ???
+  implicit val system: ActorSystem[?] = ???
   trait MyEvent
   trait MyState
 

--- a/docs/src/test/scala/docs/home/state/BlogPostCounts.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPostCounts.scala
@@ -47,7 +47,7 @@ pekko.persistence.r2dbc.state {
  * CREATE TABLE post_count (slice INT NOT NULL, cnt BIGINT NOT NULL, PRIMARY KEY(slice));
  * }}}
  */
-class BlogPostCounts(system: ActorSystem[_]) extends ChangeHandler[BlogPost.State] {
+class BlogPostCounts(system: ActorSystem[?]) extends ChangeHandler[BlogPost.State] {
 
   private val incrementSql =
     "INSERT INTO post_count (slice, cnt) VALUES ($1, 1) " +

--- a/docs/src/test/scala/docs/home/state/BlogPostQuery.scala
+++ b/docs/src/test/scala/docs/home/state/BlogPostQuery.scala
@@ -21,7 +21,7 @@ import pekko.actor.typed.ActorSystem
 import pekko.persistence.r2dbc.session.scaladsl.R2dbcSession
 import pekko.serialization.SerializationExtension
 
-class BlogPostQuery(system: ActorSystem[_]) {
+class BlogPostQuery(system: ActorSystem[?]) {
 
   private val findByTitleSql =
     "SELECT state_ser_id, state_ser_manifest, state_payload " +

--- a/migration/src/main/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationTool.scala
+++ b/migration/src/main/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationTool.scala
@@ -101,10 +101,10 @@ object MigrationTool {
  *
  * Note: tags are not migrated.
  */
-class MigrationTool(system: ActorSystem[_]) {
+class MigrationTool(system: ActorSystem[?]) {
   import MigrationTool.Result
   import system.executionContext
-  private implicit val sys: ActorSystem[_] = system
+  private implicit val sys: ActorSystem[?] = system
 
   private val log = LoggerFactory.getLogger(getClass)
 

--- a/migration/src/main/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -37,7 +37,7 @@ import io.r2dbc.spi.ConnectionFactory
  */
 @InternalApi private[r2dbc] class MigrationToolDao(
     connectionFactory: ConnectionFactory,
-    logDbCallsExceeding: FiniteDuration)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
+    logDbCallsExceeding: FiniteDuration)(implicit ec: ExecutionContext, system: ActorSystem[?]) {
   import MigrationToolDao.CurrentProgress
 
   private val r2dbcExecutor = new R2dbcExecutor(connectionFactory, log, logDbCallsExceeding)(ec, system)

--- a/migration/src/test/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationToolSpec.scala
+++ b/migration/src/test/scala/org/apache/pekko/persistence/r2dbc/migration/MigrationToolSpec.scala
@@ -74,7 +74,7 @@ class MigrationToolSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val migrationConfig = system.settings.config.getConfig("pekko.persistence.r2dbc.migration")
   private val sourceJournalPluginId = "jdbc-journal"

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -19,7 +19,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -31,10 +31,10 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override def projectSettings: Seq[Def.Setting[?]] =
     Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-persistence-r2dbc.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048