### PR TITLE
Improve Scala 3.8 forward compatibility

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/ContinuousQuery.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/ContinuousQuery.scala
@@ -86,7 +86,7 @@ final private[r2dbc] class ContinuousQuery[S, T](
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new TimerGraphStageLogicWithLogging(shape) with OutHandler {
       var nextRow: OptionVal[T] = OptionVal.none[T]
-      var sinkIn: SubSinkInlet[T] = _
+      var sinkIn: SubSinkInlet[T] = null
       var state = initialState
       var nrElements = Long.MaxValue
       var subStreamFinished = false

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -27,7 +27,17 @@ object CommonSettings extends AutoPlugin {
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "--release", "17"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
+      if (scalaBinaryVersion.value == "3")
+        Seq(
+          "-Yfuture-lazy-vals",
+          "-release:17",
+          "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+          "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+          "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+          "-Wconf:msg=with as a type operator has been deprecated:s",
+          "-Wconf:msg=Unreachable case except for null:s",
+          "-Wconf:msg=is no longer supported for vararg splices:s",
+          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
       else Seq.empty
     },
     Test / logBuffered := false,


### PR DESCRIPTION
## Summary
- Replace `= _` with `= null` in ContinuousQuery (deprecated in Scala 3.8)
- Add `-Wconf` suppressions for warnings that require Scala 3-only syntax fixes (using clauses, wildcard types, eta-expansion, with operator, vararg splices)
- Zero new warnings when compiled with Scala 3.8.4, while maintaining full cross-compilation with Scala 2.13 and 3.3.x

## Test plan
- [x] Verified clean compilation with Scala 3.8.4 (zero new warnings)
- [ ] CI passes on Scala 2.13 and 3.3.x