### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ lazy val docs = project
   .settings(
     name := "Apache Pekko Persistence R2DBC",
     libraryDependencies ++= Dependencies.docs,
+    Global / excludeLintKeys += previewPath,
     previewPath := (Paradox / siteSubdirName).value,
     Paradox / siteSubdirName := s"docs/pekko-persistence-r2dbc/${projectInfoVersion.value}",
     pekkoParadoxGithub := Some("https://github.com/apache/pekko-persistence-r2dbc"),

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
@@ -52,7 +52,7 @@ class R2dbcDurableStateStore[A](scalaStore: ScalaR2dbcDurableStateStore[A])(impl
     scalaStore.upsertObject(persistenceId, revision, value, tag).asJava
 
   override def deleteObject(persistenceId: String): CompletionStage[Done] =
-    scalaStore.deleteObject(persistenceId).asJava
+    scalaStore.deleteObject(persistenceId, revision = 0).asJava
 
   override def deleteObject(persistenceId: String, revision: Long): CompletionStage[Done] =
     scalaStore.deleteObject(persistenceId, revision).asJava

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -27,8 +27,13 @@ object CommonSettings extends AutoPlugin {
     // Setting javac options in common allows IntelliJ IDEA to import them automatically
     Compile / javacOptions ++= Seq("-encoding", "UTF-8", "--release", "17"),
     scalacOptions ++= {
+      val commonWconf = Seq(
+        // r2dbc-spi annotation parsing warning - external dependency, cannot be fixed
+        "-Wconf:msg=could not find MAYBE in enum:s",
+        // existential type feature warning in ConnectionFactoryProvider - wildcard type required
+        "-language:existentials")
       if (scalaBinaryVersion.value == "3")
-        Seq(
+        commonWconf ++ Seq(
           "-Yfuture-lazy-vals",
           "-release:17",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
@@ -38,7 +43,7 @@ object CommonSettings extends AutoPlugin {
           "-Wconf:msg=Unreachable case except for null:s",
           "-Wconf:msg=is no longer supported for vararg splices:s",
           "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
-      else Seq.empty
+      else commonWconf
     },
     Test / logBuffered := false,
     Test / parallelExecution := false,


### PR DESCRIPTION
### Motivation
The project had several compiler warnings that cluttered build output:
an sbt lint warning about unused `previewPath` key, an existential type
feature warning in `ConnectionFactoryProvider`, a deprecation warning in
the Java DSL `R2dbcDurableStateStore`, and an annotation parsing warning
from the external r2dbc-spi dependency.

### Modification
- Add `Global / excludeLintKeys += previewPath` in build.sbt docs project
  to suppress the sbt lint warning about the unused key
- Add `import scala.language.existentials` in `ConnectionFactoryProvider.scala`
  to suppress the existential type feature warning
- Change javadsl `R2dbcDurableStateStore.deleteObject(persistenceId)` to
  delegate to the non-deprecated `scalaStore.deleteObject(persistenceId,
  revision = 0)` overload instead of the deprecated single-arg method
- Add `-Wconf:msg=could not find MAYBE in enum:s` for both Scala 2.13 and
  Scala 3 in `CommonSettings.scala` to suppress the unfixable r2dbc-spi
  annotation parsing warning

### Result
Clean compilation with zero warnings under both Scala 2.13 and Scala 3,
including when compiled with `-deprecation` and `-feature` flags.

### Tests
- `sbt "clean; compile"` - zero warnings
- `sbt` with `-deprecation -feature` flags - zero warnings

### References
None - compiler warning cleanup