### PR TITLE
refactor: modernize Java test code with Java 17 features

### DIFF
--- a/core/src/test/java/org/apache/pekko/persistence/r2dbc/state/JavadslChangeHandler.java
+++ b/core/src/test/java/org/apache/pekko/persistence/r2dbc/state/JavadslChangeHandler.java
@@ -39,8 +39,7 @@ public class JavadslChangeHandler implements ChangeHandler<String> {
 
   @Override
   public CompletionStage<Done> process(R2dbcSession session, DurableStateChange<String> change) {
-    if (change instanceof UpdatedDurableState) {
-      UpdatedDurableState<String> upd = (UpdatedDurableState<String>) change;
+    if (change instanceof UpdatedDurableState<String> upd) {
       return session
           .updateOne(
               session

--- a/docs/src/test/java/jdocs/home/state/BlogPost.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPost.java
@@ -46,11 +46,11 @@ public class BlogPost
     }
 
     DraftState withBody(String newBody) {
-      return withContent(new PostContent(postId(), content.title, newBody));
+      return withContent(new PostContent(postId(), content.title(), newBody));
     }
 
     String postId() {
-      return content.postId;
+      return content.postId();
     }
   }
 
@@ -66,69 +66,26 @@ public class BlogPost
     }
 
     PublishedState withBody(String newBody) {
-      return withContent(new PostContent(postId(), content.title, newBody));
+      return withContent(new PostContent(postId(), content.title(), newBody));
     }
 
     String postId() {
-      return content.postId;
+      return content.postId();
     }
   }
 
   public interface Command {}
-  public static class AddPost implements Command {
-    final PostContent content;
-    final ActorRef<AddPostDone> replyTo;
+  public record AddPost(PostContent content, ActorRef<AddPostDone> replyTo) implements Command {}
 
-    public AddPost(PostContent content, ActorRef<AddPostDone> replyTo) {
-      this.content = content;
-      this.replyTo = replyTo;
-    }
-  }
+  public record AddPostDone(String postId) implements Command {}
 
-  public static class AddPostDone implements Command {
-    final String postId;
+  public record GetPost(ActorRef<PostContent> replyTo) implements Command {}
 
-    public AddPostDone(String postId) {
-      this.postId = postId;
-    }
-  }
-  public static class GetPost implements Command {
-    final ActorRef<PostContent> replyTo;
+  public record ChangeBody(String newBody, ActorRef<Done> replyTo) implements Command {}
 
-    public GetPost(ActorRef<PostContent> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record Publish(ActorRef<Done> replyTo) implements Command {}
 
-  public static class ChangeBody implements Command {
-    final String newBody;
-    final ActorRef<Done> replyTo;
-
-    public ChangeBody(String newBody, ActorRef<Done> replyTo) {
-      this.newBody = newBody;
-      this.replyTo = replyTo;
-    }
-  }
-
-  public static class Publish implements Command {
-    final ActorRef<Done> replyTo;
-
-    public Publish(ActorRef<Done> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
-
-  public static class PostContent implements Command {
-    final String postId;
-    final String title;
-    final String body;
-
-    public PostContent(String postId, String title, String body) {
-      this.postId = postId;
-      this.title = title;
-      this.body = body;
-    }
-  }
+  public record PostContent(String postId, String title, String body) implements Command {}
 
   public static Behavior<Command> create(String entityId, PersistenceId persistenceId) {
     return Behaviors.setup(
@@ -171,20 +128,20 @@ public class BlogPost
 
   private Effect<State> onAddPost(AddPost cmd) {
     return Effect()
-        .persist(new DraftState(cmd.content))
-        .thenRun(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
+        .persist(new DraftState(cmd.content()))
+        .thenRun(() -> cmd.replyTo().tell(new AddPostDone(cmd.content().postId())));
   }
 
   private Effect<State> onChangeBody(DraftState state, ChangeBody cmd) {
     return Effect()
-        .persist(state.withBody(cmd.newBody))
-        .thenRun(() -> cmd.replyTo.tell(Done.getInstance()));
+        .persist(state.withBody(cmd.newBody()))
+        .thenRun(() -> cmd.replyTo().tell(Done.getInstance()));
   }
 
   private Effect<State> onChangeBody(PublishedState state, ChangeBody cmd) {
     return Effect()
-        .persist(state.withBody(cmd.newBody))
-        .thenRun(() -> cmd.replyTo.tell(Done.getInstance()));
+        .persist(state.withBody(cmd.newBody()))
+        .thenRun(() -> cmd.replyTo().tell(Done.getInstance()));
   }
 
   private Effect<State> onPublish(DraftState state, Publish cmd) {
@@ -193,17 +150,17 @@ public class BlogPost
         .thenRun(
             () -> {
               System.out.println("Blog post published: " + state.postId());
-              cmd.replyTo.tell(Done.getInstance());
+              cmd.replyTo().tell(Done.getInstance());
             });
   }
 
   private Effect<State> onGetPost(DraftState state, GetPost cmd) {
-    cmd.replyTo.tell(state.content);
+    cmd.replyTo().tell(state.content);
     return Effect().none();
   }
 
   private Effect<State> onGetPost(PublishedState state, GetPost cmd) {
-    cmd.replyTo.tell(state.content);
+    cmd.replyTo().tell(state.content);
     return Effect().none();
   }
 

--- a/docs/src/test/java/jdocs/home/state/BlogPostCounts.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostCounts.java
@@ -39,8 +39,9 @@ public class BlogPostCounts implements ChangeHandler<BlogPost.State> {
   private final ActorSystem<?> system;
 
   private final String incrementSql =
-      "INSERT INTO post_count (slice, cnt) VALUES ($1, 1) " +
-          "ON CONFLICT (slice) DO UPDATE SET cnt = excluded.cnt + 1";
+      """
+      INSERT INTO post_count (slice, cnt) VALUES ($1, 1) \
+      ON CONFLICT (slice) DO UPDATE SET cnt = excluded.cnt + 1""";
 
   private final String decrementSql =
       "UPDATE post_count SET cnt = cnt - 1 WHERE slice = $1";

--- a/docs/src/test/java/jdocs/home/state/BlogPostJsonColumn.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostJsonColumn.java
@@ -33,12 +33,12 @@ public class BlogPostJsonColumn extends AdditionalColumn<BlogPost.State, Json> {
     BlogPost.State state = upsert.value();
     if (state instanceof BlogPost.DraftState s) {
       // a json library would be used here
-      String jsonString = "{\"title\": \"" + s.content.title + "\", \"published\": false}";
+      String jsonString = "{\"title\": \"" + s.content.title() + "\", \"published\": false}";
       Json json = Json.of(jsonString);
       return AdditionalColumn.bindValue(json);
     } else if (state instanceof BlogPost.PublishedState s) {
       // a json library would be used here
-      String jsonString = "{\"title\": \"" + s.content.title + "\", \"published\": true}";
+      String jsonString = "{\"title\": \"" + s.content.title() + "\", \"published\": true}";
       Json json = Json.of(jsonString);
       return AdditionalColumn.bindValue(json);
     } else {

--- a/docs/src/test/java/jdocs/home/state/BlogPostTitleColumn.java
+++ b/docs/src/test/java/jdocs/home/state/BlogPostTitleColumn.java
@@ -33,7 +33,7 @@ public class BlogPostTitleColumn extends AdditionalColumn<BlogPost.State, String
     if (state.equals(BlogPost.BlankState.INSTANCE)) {
       return AdditionalColumn.bindNull();
     } else if (state instanceof BlogPost.DraftState draft) {
-      return AdditionalColumn.bindValue(draft.content.title);
+      return AdditionalColumn.bindValue(draft.content.title());
     } else {
       return AdditionalColumn.skip();
     }


### PR DESCRIPTION
### Motivation
Java 17 introduced records, pattern matching for instanceof, and text blocks that make Java code more concise and readable.

### Modification
- Convert command data carrier classes to Java records in BlogPost
- Use pattern matching for instanceof in JavadslChangeHandler
- Use text blocks for multi-line SQL in BlogPostCounts
- Update field accesses to use record accessor methods

### Result
Test Java code is more concise and idiomatic for Java 17+.

### Tests
- `sbt "docs / compile"` (to be verified by CI)

### References
None - code modernization