### PR TITLE
Use Locale.ROOT for string comparison in R2dbcSettings

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -209,7 +209,7 @@ trait ConnectionSettings {
     }
 
   protected def useJsonPayload(configKey: String): Boolean =
-    config.getString(configKey).toUpperCase match {
+    config.getString(configKey).toUpperCase(Locale.ROOT) match {
       case "BYTEA"          => false
       case "JSONB" | "JSON" => true
       case t                =>


### PR DESCRIPTION
other code in this class uses Locale Root but this usage is missing it