### PR TITLE
refactor: replace deprecated deleteObject(persistenceId) with revision overload

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
@@ -120,7 +120,7 @@ class DurableStateStoreSpec
       val value = "Genuinely Collaborative"
       store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
       store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
-      store.deleteObject(persistenceId).futureValue
+      store.deleteObject(persistenceId, revision = 1L).futureValue
       store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 0L))
     }
 


### PR DESCRIPTION
### Motivation
`DurableStateUpdateStore.deleteObject(persistenceId)` (1-arg form) has been deprecated since Akka 2.6.20 in favor of `deleteObject(persistenceId, revision)`.

### Modification
Replace `store.deleteObject(persistenceId)` with `store.deleteObject(persistenceId, revision = 1L)` in `DurableStateStoreSpec.scala`, matching the revision used in the preceding `upsertObject` call.

### Result
Removes usage of deprecated `deleteObject` overload in test code.

### Tests
- `sbt "core / Test / compile"` — success

### References
None — deprecated API cleanup