### PR TITLE
fix: fix scaladoc warnings in core module

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -49,7 +49,7 @@ object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] 
   def get(system: ActorSystem[?]): ConnectionFactoryProvider = apply(system)
 
   /**
-   * Enables customization of [[ConnectionFactoryOptions]] right before the connection factory is created.
+   * Enables customization of `ConnectionFactoryOptions` right before the connection factory is created.
    * This is particularly useful for setting options that support dynamically computed values rather than
    * just plain constants. Classes implementing this trait must have a constructor with a single parameter
    * of type [[ActorSystem]].
@@ -59,7 +59,7 @@ object ConnectionFactoryProvider extends ExtensionId[ConnectionFactoryProvider] 
   trait ConnectionFactoryOptionsCustomizer {
 
     /**
-     * Customizes the [[ConnectionFactoryOptions.Builder]] instance based on the provided configuration.
+     * Customizes the `ConnectionFactoryOptions.Builder` instance based on the provided configuration.
      *
      * @param builder the options builder that has been pre-configured by the connection factory provider
      * @param config  the connection factory configuration

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/Sql.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/Sql.scala
@@ -62,7 +62,7 @@ object Sql {
 
   /**
    * Java API: Replaces `?` with numbered `\$1`, `\$2` for bind parameters. Use `??` to include a literal `?`. Trims
-   * whitespace, including line breaks. The arguments are used like in [[java.lang.String.format]].
+   * whitespace, including line breaks. The arguments are used like in `java.lang.String.format`.
    */
   @varargs
   def format(sql: String, args: AnyRef*): String =

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/javadsl/R2dbcReadJournal.scala
@@ -117,7 +117,7 @@ final class R2dbcReadJournal(delegate: scaladsl.R2dbcReadJournal)
    *
    * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
    * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
-   * [[pekko.persistence.typed.PersistenceId]].
+   * [[org.apache.pekko.persistence.typed.PersistenceId PersistenceId]].
    *
    * @param entityType
    *   The entity type name.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -141,7 +141,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
    * The consumer can keep track of its current position in the event stream by storing the `offset` and restart the
    * query from a given `offset` after a crash/restart.
    *
-   * The supported offset is [[TimestampOffset]] and [[Offset.noOffset]].
+   * The supported offset is [[org.apache.pekko.persistence.query.TimestampOffset TimestampOffset]] and [[Offset.noOffset]].
    *
    * The timestamp is based on the database `transaction_timestamp()` when the event was stored.
    * `transaction_timestamp()` is the time when the transaction started, not when it was committed. This means that a
@@ -451,7 +451,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
    *
    * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
    * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
-   * [[pekko.persistence.typed.PersistenceId]].
+   * [[org.apache.pekko.persistence.typed.PersistenceId PersistenceId]].
    *
    * @param entityType
    *   The entity type name.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/ChangeHandler.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/ChangeHandler.scala
@@ -29,7 +29,7 @@ trait ChangeHandler[A] {
    * delete.
    *
    * The `process` method is invoked for each `DurableStateChange`. Each time a new `Connection` is passed with a new
-   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[R2dbcSession]]. The
+   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[org.apache.pekko.persistence.r2dbc.session.javadsl.R2dbcSession R2dbcSession]]. The
    * results of several statements can be combined with `CompletionStage` composition (e.g. `thenCompose`). The
    * transaction will be automatically committed or rolled back when the returned `CompletionStage` is completed. Note
    * that an exception here will abort the transaction and fail the upsert or delete.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
@@ -92,7 +92,7 @@ class R2dbcDurableStateStore[A](scalaStore: ScalaR2dbcDurableStateStore[A])(impl
    *
    * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
    * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
-   * [[pekko.persistence.typed.PersistenceId]].
+   * [[org.apache.pekko.persistence.typed.PersistenceId PersistenceId]].
    *
    * @param entityType
    *   The entity type name.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/ChangeHandler.scala
@@ -29,7 +29,7 @@ trait ChangeHandler[A] {
    * delete.
    *
    * The `process` method is invoked for each `DurableStateChange`. Each time a new `Connection` is passed with a new
-   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[R2dbcSession]]. The
+   * open transaction. You can use `createStatement`, `update` and other methods provided by the [[org.apache.pekko.persistence.r2dbc.session.scaladsl.R2dbcSession R2dbcSession]]. The
    * results of several statements can be combined with `Future` composition. The transaction will be automatically
    * committed or rolled back when the returned `Future` is completed. Note that an exception here will abort the
    * transaction and fail the upsert or delete.

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -178,7 +178,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
    *
    * Note: to reuse existing index, the actual query filters entity types based on persistence_id column and sql LIKE
    * operator. Hence the persistenceId must start with an entity type followed by default separator ("|") from
-   * [[pekko.persistence.typed.PersistenceId]].
+   * [[org.apache.pekko.persistence.typed.PersistenceId PersistenceId]].
    *
    * @param entityType
    *   The entity type name.


### PR DESCRIPTION
### Motivation
Running `sbt doc` produces scaladoc warnings about unresolvable or ambiguous links in the core module.

### Modification
- `ConnectionFactoryProvider.scala`: Replace broken links to external `io.r2dbc` types (`ConnectionFactoryOptions`, `ConnectionFactoryOptions.Builder`) with backtick-quoted code
- `internal/Sql.scala`: Replace ambiguous `java.lang.String.format` link with backtick-quoted code
- `query/javadsl/R2dbcReadJournal.scala`: Use fully qualified `org.apache.pekko.persistence.typed.PersistenceId` path
- `query/scaladsl/R2dbcReadJournal.scala`: Use fully qualified paths for `TimestampOffset` and `PersistenceId`
- `state/javadsl/ChangeHandler.scala`: Use fully qualified path for `R2dbcSession` link
- `state/javadsl/R2dbcDurableStateStore.scala`: Use fully qualified `org.apache.pekko.persistence.typed.PersistenceId` path
- `state/scaladsl/ChangeHandler.scala`: Use fully qualified path for `R2dbcSession` link
- `state/scaladsl/R2dbcDurableStateStore.scala`: Use fully qualified `org.apache.pekko.persistence.typed.PersistenceId` path

### Result
Scaladoc warnings are eliminated.

### Tests
Not run - docs only

### References
None