### PR TITLE
feat: add Scala 3.8.4 cross-compilation target

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3 ]
+        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
         JAVA_VERSION: [ 17, 21 ]
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3 ]
+        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3 ]
+        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3 ]
+        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3 ]
+        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
         JAVA_VERSION: [ 17, 21 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -21,7 +21,7 @@ object CommonSettings extends AutoPlugin {
   override def requires = JvmPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   override lazy val projectSettings = Seq(
-    crossScalaVersions := Seq(Dependencies.Scala213, Dependencies.Scala3),
+    crossScalaVersions := Seq(Dependencies.Scala213, Dependencies.Scala3, Dependencies.Scala3Next),
     scalaVersion := Dependencies.Scala213,
     crossVersion := CrossVersion.binary,
     // Setting javac options in common allows IntelliJ IDEA to import them automatically

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ import sbt._
 object Dependencies {
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
+  val Scala3Next = "3.8.4"
   val PekkoVersion = PekkoCoreDependency.version
   val PekkoVersionInDocs = PekkoCoreDependency.default.link
   val PekkoPersistenceJdbcVersion = PekkoPersistenceJdbcDependency.version


### PR DESCRIPTION
### Motivation
Ensure pekko-persistence-r2dbc compiles and tests pass on the next Scala 3 release line (3.8.x), preparing for future Scala 3.9.x compatibility.

### Modification
- Add `Scala3Next = "3.8.4"` to Dependencies.scala
- Add Scala 3.8.4 to `crossScalaVersions` in CommonSettings.scala
- Add `3.8` to CI matrix in build-test.yml (all test jobs)

### Result
CI now compiles and tests against Scala 2.13, 3.3, and 3.8. Publishing continues with Scala 3.3.8.

### Tests
CI will validate

### References
None - proactive compatibility testing