### PR TITLE
fix: fix compilation warnings across all Scala versions

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanupSpec.scala
@@ -220,7 +220,7 @@ class EventSourcedCleanupSpec
       })
 
       (1 to 10).foreach { n =>
-        p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+        p ! Persister.PersistWithAck(s"${if (n == 3) s"$n-snap" else n}", ackProbe.ref)
         ackProbe.expectMessage(Done)
       }
 
@@ -252,7 +252,7 @@ class EventSourcedCleanupSpec
       })
 
       (1 to 10).foreach { n =>
-        p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+        p ! Persister.PersistWithAck(s"${if (n == 3) s"$n-snap" else n}", ackProbe.ref)
         ackProbe.expectMessage(Done)
       }
 
@@ -290,7 +290,7 @@ class EventSourcedCleanupSpec
 
       (1 to 10).foreach { n =>
         persisters.foreach { p =>
-          p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+          p ! Persister.PersistWithAck(s"${if (n == 3) s"$n-snap" else n}", ackProbe.ref)
           ackProbe.expectMessage(Done)
         }
       }
@@ -324,7 +324,7 @@ class EventSourcedCleanupSpec
 
       (1 to 10).foreach { n =>
         persisters.foreach { p =>
-          p ! Persister.PersistWithAck(s"${if (n == 3) n + "-snap" else n}", ackProbe.ref)
+          p ! Persister.PersistWithAck(s"${if (n == 3) s"$n-snap" else n}", ackProbe.ref)
           ackProbe.expectMessage(Done)
         }
       }

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/state/DurableStateStoreSpec.scala
@@ -120,8 +120,8 @@ class DurableStateStoreSpec
       val value = "Genuinely Collaborative"
       store.upsertObject(persistenceId, 1L, value, unusedTag).futureValue
       store.getObject(persistenceId).futureValue should be(GetObjectResult(Some(value), 1L))
-      store.deleteObject(persistenceId).futureValue
-      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 0L))
+      store.deleteObject(persistenceId, 2L).futureValue
+      store.getObject(persistenceId).futureValue should be(GetObjectResult(None, 2L))
     }
 
     "hard delete when revision=0" in {


### PR DESCRIPTION
### Motivation
Compilation produced 5 deprecation warnings across all Scala versions (2.13.18, 3.3.8, 3.8.4):
- 4 warnings for deprecated `Int + String` concatenation (since Scala 2.13.0)
- 1 warning for deprecated `deleteObject(persistenceId)` without revision parameter (since 1.0.0)

### Modification
- Replace deprecated `n + "-snap"` with string interpolation `s"$n-snap"` in `EventSourcedCleanupSpec.scala` (4 occurrences)
- Replace deprecated `deleteObject(persistenceId)` with `deleteObject(persistenceId, 2L)` in `DurableStateStoreSpec.scala`, using proper optimistic locking revision (1 + 1 = 2)

### Result
Clean compilation with zero warnings across all Scala versions (2.13.18, 3.3.8, 3.8.4).

### Tests
- `sbt +test:compile` - all versions pass with no warnings

### References
None - code quality improvement