### PR TITLE
chore: update scala3Next to 3.9.0-RC3

### DIFF
--- a/.github/scripts/resolve-scala-version.sh
+++ b/.github/scripts/resolve-scala-version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+scala_version="${1:?scala version is required}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+resolve_from_build() {
+  local pattern="$1"
+  local resolved
+  resolved="$(sed -n "$pattern" "$repo_root/project/Dependencies.scala")"
+  if [ -z "$resolved" ]; then
+    echo "Unable to resolve Scala version '$scala_version' from project/Dependencies.scala" >&2
+    exit 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+case "$scala_version" in
+  2.13 | 2.13.x | scala213)
+    resolve_from_build 's/.*val Scala213 = "\(.*\)".*/\1/p'
+    ;;
+  3.3 | 3.3.x | scala3)
+    resolve_from_build 's/.*val Scala3 = "\(.*\)".*/\1/p'
+    ;;
+  next)
+    resolve_from_build 's/.*val Scala3Next = "\(.*\)".*/\1/p'
+    ;;
+  *)
+    printf '%s\n' "$scala_version"
+    ;;
+esac

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Report MiMa Binary Issues
         run: |-
-          sbt +mimaReportBinaryIssues
+          scala_2_13="$(bash .github/scripts/resolve-scala-version.sh "2.13")"
+          scala_3="$(bash .github/scripts/resolve-scala-version.sh "3.3")"
+          sbt "++${scala_2_13}! mimaReportBinaryIssues" "++${scala_3}! mimaReportBinaryIssues"
 
       - name: Check correct MiMa filter directories
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
+        SCALA_VERSION: [ 2.13, 3.3, next ]
         JAVA_VERSION: [ 17, 21 ]
     steps:
       - name: Checkout
@@ -38,14 +38,16 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile and test for JDK ${{ matrix.JAVA_VERSION }}, Scala ${{ matrix.SCALA_VERSION }}
-        run: sbt ++${{ matrix.SCALA_VERSION }} test:compile
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.SCALA_VERSION }}")"
+          sbt "++${scala_version}!" test:compile
 
   test-postgres:
     name: Run test with Postgres
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
+        SCALA_VERSION: [ 2.13, 3.3, next ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -95,14 +97,16 @@ jobs:
           docker exec -i docker-postgres-db-1 psql -U postgres -t -d database2 < ddl-scripts/create_tables_postgres.sql
 
       - name: test
-        run: sbt ++${{ matrix.SCALA_VERSION }} test
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.SCALA_VERSION }}")"
+          sbt "++${scala_version}!" test
 
   test-postgres-jsonb:
     name: Run test with Postgres (JSONB)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
+        SCALA_VERSION: [ 2.13, 3.3, next ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -156,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
+        SCALA_VERSION: [ 2.13, 3.3, next ]
         JAVA_VERSION: [ 17 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -206,14 +210,16 @@ jobs:
           docker exec -i yb-tserver-n1 /home/yugabyte/bin/ysqlsh -h yb-tserver-n1 -t -d database2 < ddl-scripts/create_tables_yugabyte.sql
 
       - name: test
-        run: sbt -Dpekko.persistence.r2dbc.dialect=yugabyte ++${{ matrix.SCALA_VERSION }} test
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.SCALA_VERSION }}")"
+          sbt -Dpekko.persistence.r2dbc.dialect=yugabyte "++${scala_version}!" test
 
   test-mysql:
     name: Run tests with MySQL
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SCALA_VERSION: [ 2.13, 3.3, 3.8 ]
+        SCALA_VERSION: [ 2.13, 3.3, next ]
         JAVA_VERSION: [ 17, 21 ]
     if: github.repository == 'apache/pekko-persistence-r2dbc'
     steps:
@@ -263,7 +269,9 @@ jobs:
           docker exec -i docker-mysql-db-1 mysql -h 127.0.0.1 --user=root --password=root --database=database2 < ddl-scripts/create_tables_mysql.sql
 
       - name: test
-        run: sbt -Dpekko.persistence.r2dbc.dialect=mysql ++${{ matrix.SCALA_VERSION }} ${{ matrix.COMPILE_ONLY && 'Test/compile' || 'test' }}
+        run: |-
+          scala_version="$(bash .github/scripts/resolve-scala-version.sh "${{ matrix.SCALA_VERSION }}")"
+          sbt -Dpekko.persistence.r2dbc.dialect=mysql "++${scala_version}!" ${{ matrix.COMPILE_ONLY && 'Test/compile' || 'test' }}
 
   test-docs:
     name: Docs

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ import sbt._
 object Dependencies {
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.9.0-RC1"
+  val Scala3Next = "3.9.0-RC3"
   val PekkoVersion = PekkoCoreDependency.version
   val PekkoVersionInDocs = PekkoCoreDependency.default.link
   val PekkoPersistenceJdbcVersion = PekkoPersistenceJdbcDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ import sbt._
 object Dependencies {
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.8.4"
+  val Scala3Next = "3.9.0-RC1"
   val PekkoVersion = PekkoCoreDependency.version
   val PekkoVersionInDocs = PekkoCoreDependency.default.link
   val PekkoPersistenceJdbcVersion = PekkoPersistenceJdbcDependency.version


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump