### PR TITLE
fix intermittent test failure in EventsBySlicePubSubSpec

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
@@ -331,13 +331,18 @@ class EventsBySlicePubSubSpec
         }
       }
 
+      // warmup: ensure all streams are fully ready to receive events before the real assertions
+      val queryIndex = querySliceRanges.indexOf(querySliceRanges.find(_.contains(slice)).get)
+      persister ! PersistWithAck("warmup", probe.ref)
+      probe.expectMessage(Done)
+      queries(queryIndex).expectNext(5.seconds).event shouldBe "warmup"
+
       for (i <- 1 to 10) {
         persister ! PersistWithAck(s"e-$i", probe.ref)
         probe.expectMessage(Done)
       }
 
       for (i <- 1 to 10) {
-        val queryIndex = querySliceRanges.indexOf(querySliceRanges.find(_.contains(slice)).get)
         queries(queryIndex).expectNext().event shouldBe s"e-$i"
       }
 


### PR DESCRIPTION
```
should group slices into topics *** FAILED *** (3 seconds, 564 milliseconds)                                                       
  [info]   "e-[2]" was not equal to "e-[1]" (EventsBySlicePubSubSpec.scala:341)                                                                                      
  [info]   org.scalatest.exceptions.TestFailedException:                                                                                                             
  [info]   at org.scalatest.matchers.MatchersHelper$.indicateFailure(MatchersHelper.scala:392)                                                                       
  [info]   at org.scalatest.matchers.should.Matchers.shouldBe(Matchers.scala:7017)                                                                                   
  [info]   at org.scalatest.matchers.should.Matchers.shouldBe$(Matchers.scala:1808)                                                                                  
  [info]   at org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit.shouldBe(ScalaTestWithActorTestKit.scala:42)                                   
  [info]   at org.apache.pekko.persistence.r2dbc.query.EventsBySlicePubSubSpec$$anon$3.$init$$$anonfun$16(EventsBySlicePubSubSpec.scala:341)                         
  [info]   at org.apache.pekko.persistence.r2dbc.query.EventsBySlicePubSubSpec$$anon$3.$init$$$anonfun$adapted$9(EventsBySlicePubSubSpec.scala:339)                  
  [info]   at scala.collection.immutable.Range.foreach(Range.scala:256)                                                                                              
  [info]   at org.apache.pekko.persistence.r2dbc.query.EventsBySlicePubSubSpec$$anon$3.<init>(EventsBySlicePubSubSpec.scala:339)                                     
  [info]   at org.apache.pekko.persistence.r2dbc.query.EventsBySlicePubSubSpec.f$proxy7$1(EventsBySlicePubSubSpec.scala:310)                                         
  [info]   at org.apache.pekko.persistence.r2dbc.query.EventsBySlicePubSubSpec.$init$$$anonfun$1$$anonfun$7(EventsBySlicePubSubSpec.scala:310)                       
  [info]   at org.scalatest.Transformer.apply$$anonfun$1(Transformer.scala:22) 
```