### PR TITLE
more timeout checks

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -250,6 +250,10 @@ class R2dbcExecutor(
       logPrefix: String)(statement: Connection => Statement, mapRow: Row => A): Future[immutable.IndexedSeq[A]] = {
     getConnection(logPrefix).flatMap { connection =>
       val startTime = nanoTime()
+      val timeoutTask = closeCallsExceeding.map { timeout =>
+        system.scheduler.scheduleOnce(timeout, () => closeAfterTimeout(connection))
+      }
+
       val mappedRows =
         try {
           val boundStmt = statement(connection)
@@ -262,17 +266,20 @@ class R2dbcExecutor(
 
       mappedRows.failed.foreach { exc =>
         log.debug("{} - Select failed: {}", logPrefix: Any, exc: Any)
-        connection.close().asFutureDone()
+        val done = connection.close().asFutureDone()
+        timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
       }
 
       mappedRows.flatMap { r =>
-        connection.close().asFutureDone().map { _ =>
+        val done = connection.close().asFutureDone().map { _ =>
           val durationMicros = durationInMicros(startTime)
           if (durationMicros >= logDbCallsExceedingMicros)
             log.info("{} - Selected [{}] rows in [{}] µs", logPrefix, r.size: java.lang.Integer,
               durationMicros: java.lang.Long)
           r
         }
+        timeoutTask.foreach { task => done.onComplete(_ => task.cancel()) }
+        done
       }
 
     }


### PR DESCRIPTION
based on a review comment in #457 

fyi @He-Pin 

The fix adds timeout protection to select() matching the pattern used in withConnection and withAutoCommitConnection:
     
  1. Line 253-255: Schedules closeAfterTimeout using closeCallsExceeding timeout
  2. Line 270: Cancels the timeout task when connection closes after failure
  3. Line 281: Cancels the timeout task when connection closes after success