### PR TITLE
job to publish 1.x snapshots

### DIFF
--- a/.github/workflows/publish-snapshot-1.x.yml
+++ b/.github/workflows/publish-snapshot-1.x.yml
@@ -1,9 +1,7 @@
-name: Publish Nightly
+name: Publish Snapshot (1.x)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
 
 jobs:
   publish:
@@ -17,15 +15,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: 1.3.x
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
 
       - name: Install sbt
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8


### PR DESCRIPTION
probably not enough happening on the 1.x branches to justify a scheduled nightly build but useful to have the ability to manually request a build