### PR TITLE
chore: drop redundant scala.collection.immutable prefixes

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/R2dbcSettings.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.r2dbc
 
 import java.util.Locale
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
@@ -140,7 +139,7 @@ final class StateSettings(val config: Config) extends ConnectionSettings with Us
   /**
    * INTERNAL API
    */
-  @InternalApi private[pekko] val durableStateAdditionalColumnClasses: Map[String, immutable.IndexedSeq[String]] = {
+  @InternalApi private[pekko] val durableStateAdditionalColumnClasses: Map[String, IndexedSeq[String]] = {
     val cfg = config.getConfig("additional-columns")
     cfg.root.unwrapped.asScala.toMap.map {
       case (k, v: java.util.List[?]) => k -> v.iterator.asScala.map(_.toString).toVector

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/DurableStateCleanup.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.r2dbc.cleanup.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Failure
@@ -98,12 +97,12 @@ final class DurableStateCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * Delete all states related to the given list of `persistenceIds`.
    */
-  def deleteStates(persistenceIds: immutable.Seq[String], resetRevisionNumber: Boolean): Future[Done] = {
+  def deleteStates(persistenceIds: Seq[String], resetRevisionNumber: Boolean): Future[Done] = {
     foreach(persistenceIds, "deleteStates", pid => deleteState(pid, resetRevisionNumber))
   }
 
   private def foreach(
-      persistenceIds: immutable.Seq[String],
+      persistenceIds: Seq[String],
       operationName: String,
       pidOperation: String => Future[Done]): Future[Done] = {
     val size = persistenceIds.size

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.r2dbc.cleanup.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
@@ -120,7 +119,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * Delete all events related to the given list of `persistenceIds`. Snapshots are not deleted.
    */
-  def deleteAllEvents(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+  def deleteAllEvents(persistenceIds: Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
     foreach(persistenceIds, "deleteAllEvents", pid => deleteAllEvents(pid, resetSequenceNumber))
   }
 
@@ -136,7 +135,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * Delete all snapshots related to the given list of `persistenceIds`. Events are not deleted.
    */
-  def deleteSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
+  def deleteSnapshots(persistenceIds: Seq[String]): Future[Done] = {
     foreach(persistenceIds, "deleteSnapshots", pid => deleteSnapshot(pid))
   }
 
@@ -154,7 +153,7 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * See single persistenceId overload for what is done for each persistence id.
    */
-  def cleanupBeforeSnapshot(persistenceIds: immutable.Seq[String]): Future[Done] = {
+  def cleanupBeforeSnapshot(persistenceIds: Seq[String]): Future[Done] = {
     foreach(persistenceIds, "cleanupBeforeSnapshot", pid => cleanupBeforeSnapshot(pid))
   }
 
@@ -171,12 +170,12 @@ final class EventSourcedCleanup(systemProvider: ClassicActorSystemProvider, conf
   /**
    * Delete everything related to the given list of `persistenceIds`. All events and snapshots are deleted.
    */
-  def deleteAll(persistenceIds: immutable.Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
+  def deleteAll(persistenceIds: Seq[String], resetSequenceNumber: Boolean): Future[Done] = {
     foreach(persistenceIds, "deleteAll", pid => deleteAll(pid, resetSequenceNumber))
   }
 
   private def foreach(
-      persistenceIds: immutable.Seq[String],
+      persistenceIds: Seq[String],
       operationName: String,
       pidOperation: String => Future[Done]): Future[Done] = {
     val size = persistenceIds.size

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.r2dbc.internal
 
 import java.util.function.BiConsumer
 
-import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -74,10 +73,10 @@ import reactor.core.publisher.Mono
       .asFuture()
   }
 
-  def updateInTx(statements: immutable.IndexedSeq[Statement])(implicit
-      ec: ExecutionContext): Future[immutable.IndexedSeq[Long]] =
+  def updateInTx(statements: IndexedSeq[Statement])(implicit
+      ec: ExecutionContext): Future[IndexedSeq[Long]] =
     // connection not intended for concurrent calls, make sure statements are executed one at a time
-    statements.foldLeft(Future.successful(immutable.IndexedSeq.empty[Long])) { (acc, stmt) =>
+    statements.foldLeft(Future.successful(IndexedSeq.empty[Long])) { (acc, stmt) =>
       acc.flatMap { seq =>
         stmt.execute().asFuture().flatMap { res =>
           res.getRowsUpdated.asFuture().map(seq :+ _.longValue())(ExecutionContext.parasitic)
@@ -95,15 +94,15 @@ import reactor.core.publisher.Mono
   def selectInTx[A](statement: Statement, mapRow: Row => A)(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[?]): Future[immutable.IndexedSeq[A]] = {
+      system: ActorSystem[?]): Future[IndexedSeq[A]] = {
     statement.execute().asFuture().flatMap { result =>
-      val consumer: BiConsumer[mutable.Builder[A, immutable.IndexedSeq[A]], A] = (builder, elem) => builder += elem
+      val consumer: BiConsumer[mutable.Builder[A, IndexedSeq[A]], A] = (builder, elem) => builder += elem
       Flux
         .from[A](result.map((row, _) => mapRow(row)))
-        .collect(() => immutable.IndexedSeq.newBuilder[A], consumer)
+        .collect(() => IndexedSeq.newBuilder[A], consumer)
         // Explicit type annotation required for map due to Scala 2.12,
         // see https://github.com/scala/bug/issues/9756#issuecomment-292440564
-        .map[immutable.IndexedSeq[A]](_.result())
+        .map[IndexedSeq[A]](_.result())
         .asFuture()
     }
   }
@@ -164,7 +163,7 @@ class R2dbcExecutor(
   /**
    * Run DDL statements in the same transaction.
    */
-  def executeDdls(logPrefix: String)(statementFactory: Connection => immutable.IndexedSeq[Statement]): Future[Done] =
+  def executeDdls(logPrefix: String)(statementFactory: Connection => IndexedSeq[Statement]): Future[Done] =
     withConnection(logPrefix) { connection =>
       val stmts = statementFactory(connection)
       // connection not intended for concurrent calls, make sure statements are executed one at a time
@@ -197,7 +196,7 @@ class R2dbcExecutor(
    * Several update statements in the same transaction.
    */
   def update(logPrefix: String)(
-      statementsFactory: Connection => immutable.IndexedSeq[Statement]): Future[immutable.IndexedSeq[Long]] =
+      statementsFactory: Connection => IndexedSeq[Statement]): Future[IndexedSeq[Long]] =
     withConnection(logPrefix) { connection =>
       updateInTx(statementsFactory(connection))
     }
@@ -229,7 +228,7 @@ class R2dbcExecutor(
    */
   def updateInBatchReturning[A](logPrefix: String)(
       statementFactory: Connection => Statement,
-      mapRow: Row => A): Future[immutable.IndexedSeq[A]] = {
+      mapRow: Row => A): Future[IndexedSeq[A]] = {
     import scala.jdk.CollectionConverters._
     withConnection(logPrefix) { connection =>
       val stmt = statementFactory(connection)
@@ -247,7 +246,7 @@ class R2dbcExecutor(
   }
 
   def select[A](
-      logPrefix: String)(statement: Connection => Statement, mapRow: Row => A): Future[immutable.IndexedSeq[A]] = {
+      logPrefix: String)(statement: Connection => Statement, mapRow: Row => A): Future[IndexedSeq[A]] = {
     getConnection(logPrefix).flatMap { connection =>
       val startTime = nanoTime()
       val timeoutTask = closeCallsExceeding.map { timeout =>

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.r2dbc.journal
 
 import java.time.Instant
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 
@@ -104,7 +103,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
     writesInProgress.remove(pid, f)
   }
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     def atomicWrite(atomicWrite: AtomicWrite): Future[Instant] = {
       val timestamp = if (journalSettings.useAppTimestamp) InstantFactory.now() else JournalDao.EmptyDbTimestamp
       val serialized: Try[Seq[SerializedJournalRow]] = Try {
@@ -178,7 +177,7 @@ private[r2dbc] final class R2dbcJournal(config: Config, cfgPath: String) extends
     writeAndPublishResult.map(_ => Nil)(ExecutionContext.parasitic)
   }
 
-  private def publish(messages: immutable.Seq[AtomicWrite], dbTimestamp: Future[Instant]): Future[Done] =
+  private def publish(messages: Seq[AtomicWrite], dbTimestamp: Future[Instant]): Future[Done] =
     pubSub match {
       case Some(ps) =>
         dbTimestamp.map { timestamp =>

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence.r2dbc.query.scaladsl
 import java.time.Instant
 import java.time.{ Duration => JDuration }
 
-import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -123,7 +122,7 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
     persistenceExt.sliceForPersistenceId(persistenceId)
   }
 
-  override def sliceRanges(numberOfRanges: Int): immutable.Seq[Range] =
+  override def sliceRanges(numberOfRanges: Int): Seq[Range] =
     persistenceExt.sliceRanges(numberOfRanges)
 
   override def currentEventsBySlices[Event](

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/session/scaladsl/R2dbcSession.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.r2dbc.session.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -68,13 +67,13 @@ final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionC
   def updateOne(statement: Statement): Future[Long] =
     R2dbcExecutor.updateOneInTx(statement)
 
-  def update(statements: immutable.IndexedSeq[Statement]): Future[immutable.IndexedSeq[Long]] =
+  def update(statements: IndexedSeq[Statement]): Future[IndexedSeq[Long]] =
     R2dbcExecutor.updateInTx(statements)
 
   def selectOne[A](statement: Statement)(mapRow: Row => A): Future[Option[A]] =
     R2dbcExecutor.selectOneInTx(statement, mapRow)
 
-  def select[A](statement: Statement)(mapRow: Row => A): Future[immutable.IndexedSeq[A]] =
+  def select[A](statement: Statement)(mapRow: Row => A): Future[IndexedSeq[A]] =
     R2dbcExecutor.selectInTx(statement, mapRow)
 
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -17,7 +17,6 @@ import java.lang
 import java.time.Instant
 import java.util
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.control.NonFatal
@@ -136,7 +135,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
     if (tags.isEmpty) stmt.bindNull(index, classOf[Array[String]])
     else stmt.bind(index, tags.toArray)
 
-  private lazy val additionalColumns: Map[String, immutable.IndexedSeq[AdditionalColumn[Any, Any]]] = {
+  private lazy val additionalColumns: Map[String, IndexedSeq[AdditionalColumn[Any, Any]]] = {
     settings.durableStateAdditionalColumnClasses.map { case (entityType, columnClasses) =>
       val instances = columnClasses.map(fqcn => AdditionalColumnFactory.create(system, fqcn))
       entityType -> instances
@@ -178,7 +177,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
 
   private def insertStateSql(
       entityType: String,
-      additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     val table = settings.getDurableStateTableWithSchema(entityType)
     val additionalCols = additionalInsertColumns(additionalBindings)
     val additionalParams = additionalInsertParameters(additionalBindings)
@@ -189,7 +188,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   }
 
   private def additionalInsertColumns(
-      additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     if (additionalBindings.isEmpty) ""
     else {
       val strB = new lang.StringBuilder()
@@ -205,7 +204,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   }
 
   private def additionalInsertParameters(
-      additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     if (additionalBindings.isEmpty) ""
     else {
       val strB = new lang.StringBuilder()
@@ -222,7 +221,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   private def updateStateSql(
       entityType: String,
       updateTags: Boolean,
-      additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     val table = settings.getDurableStateTableWithSchema(entityType)
 
     val timestamp =
@@ -247,7 +246,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   }
 
   private def additionalUpdateParameters(
-      additionalBindings: immutable.IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
+      additionalBindings: IndexedSeq[EvaluatedAdditionalColumnBindings]): String = {
     if (additionalBindings.isEmpty) ""
     else {
       val strB = new lang.StringBuilder()
@@ -742,8 +741,8 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
       persistenceIdsFromTable(afterId, limit, stateTable)
     else {
       def readFromCustomTables(
-          acc: immutable.IndexedSeq[String],
-          remainingTables: Vector[String]): Future[immutable.IndexedSeq[String]] = {
+          acc: IndexedSeq[String],
+          remainingTables: Vector[String]): Future[IndexedSeq[String]] = {
         if (acc.size >= limit) {
           Future.successful(acc)
         } else if (remainingTables.isEmpty) {
@@ -782,7 +781,7 @@ private[r2dbc] class DurableStateDao(settings: StateSettings, connectionFactory:
   private def readPersistenceIds(
       afterId: Option[String],
       limit: Long,
-      table: String): Future[immutable.IndexedSeq[String]] = {
+      table: String): Future[IndexedSeq[String]] = {
     val result = r2dbcExecutor.select(s"select persistenceIds")(
       connection =>
         afterId match {

--- a/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.r2dbc.state.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
 import com.typesafe.config.Config
@@ -153,7 +152,7 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
   override def sliceForPersistenceId(persistenceId: String): Int =
     persistenceExt.sliceForPersistenceId(persistenceId)
 
-  override def sliceRanges(numberOfRanges: Int): immutable.Seq[Range] =
+  override def sliceRanges(numberOfRanges: Int): Seq[Range] =
     persistenceExt.sliceRanges(numberOfRanges)
 
   override def currentChangesBySlices(

--- a/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/r2dbc/query/EventsBySlicePubSubSpec.scala
@@ -17,7 +17,6 @@ import java.time.Instant
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.collection.immutable
 import scala.jdk.DurationConverters._
 
 import org.apache.pekko
@@ -312,7 +311,7 @@ class EventsBySlicePubSubSpec
       val numberOfTopics =
         typedSystem.settings.config.getInt("pekko.persistence.r2dbc.journal.publish-events-number-of-topics")
       val querySliceRanges = Persistence(typedSystem).sliceRanges(numberOfTopics * 2)
-      val queries: immutable.IndexedSeq[TestSubscriber.Probe[EventEnvelope[String]]] = {
+      val queries: IndexedSeq[TestSubscriber.Probe[EventEnvelope[String]]] = {
         querySliceRanges.map { range =>
           query
             .eventsBySlices[String](setupEntityType, range.min, range.max, NoOffset)


### PR DESCRIPTION
### Motivation
The build targets Scala 2.13 and 3, where `Seq` and `IndexedSeq` already alias the immutable collections. The explicit `immutable.Seq` / `immutable.IndexedSeq` spellings are a leftover from the Scala 2.12 era of the original source and add noise.

### Modification
Replace `immutable.Seq` / `immutable.IndexedSeq` with `Seq` / `IndexedSeq` and drop the now unused `import scala.collection.immutable` in core main and test sources (10 files). `immutable.SortedMap` in `BySliceQuery` is kept because `SortedMap` has no immutable alias in the `scala` package.

Public signatures in `EventSourcedCleanup`, `DurableStateCleanup`, `R2dbcSession`, `R2dbcReadJournal` and `R2dbcDurableStateStore` are touched, but the types are identical on 2.13/3 so this is source- and binary-compatible.

### Result
No behaviour or binary change; less noise in the sources.

### Tests
- `sbt core/mimaReportBinaryIssues` against 1.0.0: no issues
- `sbt "++3.3.8" core/Test/compile migration/Test/compile`
- `sbt "core/Test/testOnly ...R2dbcJournalSpec ...EventSourcedCleanupSpec ...DurableStateCleanupSpec ...R2dbcSessionSpec ...EventsBySlicePubSubSpec ...DurableStateStoreAdditionalColumnSpec"` against local PostgreSQL: 30 passed
- `sbt core/scalafmtAll`

### References
None - housekeeping split out of the #491 review
